### PR TITLE
Scroll to current month from February on mobile

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -56,7 +56,7 @@ export function Calendar({
       return;
     }
 
-    if (now.getMonth() <= 1) {
+    if (now.getMonth() <= 0) {
       return;
     }
 


### PR DESCRIPTION
Changes the mobile auto-scroll threshold from March (3rd month) to February (2nd month).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>