### PR TITLE
Remove background color and border from header

### DIFF
--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -98,10 +98,6 @@
     position: sticky;
     top: 0;
     z-index: 10;
-    background: var(--glass-bg);
-    backdrop-filter: var(--glass-blur);
-    -webkit-backdrop-filter: var(--glass-blur);
-    border-bottom: 1px solid var(--glass-border);
     flex-wrap: wrap;
     gap: var(--spacing-md);
     margin-bottom: var(--spacing-lg);


### PR DESCRIPTION
Remove glass background, backdrop-filter, and border-bottom
from the mobile header sticky styles.

https://claude.ai/code/session_01KGFsEagVzR8P5BWMbB4kSA