### PR TITLE
Server-enforced version gating for note sync

### DIFF
--- a/src/__tests__/hydratingRepositories.test.ts
+++ b/src/__tests__/hydratingRepositories.test.ts
@@ -121,36 +121,12 @@ describe("hydrating repositories", () => {
     const dates = await repository.getAllDates();
     expect(dates).toEqual(["05-01-2025"]);
   });
-  it("preserves pending edits made during refreshEnvelope push", async () => {
-    let pushCallCount = 0;
-    let saveEnvelopeDuringPush: (() => Promise<void>) | null = null;
-
+  it("refreshEnvelope keeps local content when pending upsert and no remote", async () => {
     const gateway: RemoteNotesGateway = {
       fetchNoteByDate: jest.fn().mockResolvedValue({ ok: true, value: null }),
       fetchNoteDates: jest.fn().mockResolvedValue({ ok: true, value: [] }),
       fetchNotesSince: jest.fn().mockResolvedValue({ ok: true, value: [] }),
-      pushNote: jest.fn().mockImplementation(async (note) => {
-        pushCallCount++;
-        // Simulate a concurrent edit happening during the push
-        if (saveEnvelopeDuringPush) {
-          await saveEnvelopeDuringPush();
-          saveEnvelopeDuringPush = null;
-        }
-        return {
-          ok: true,
-          value: {
-            id: "remote-id-1",
-            date: note.date,
-            ciphertext: note.ciphertext,
-            nonce: note.nonce,
-            keyId: note.keyId,
-            revision: note.revision,
-            updatedAt: note.updatedAt,
-            serverUpdatedAt: `2025-01-05T10:00:0${pushCallCount}.000Z`,
-            deleted: false,
-          },
-        };
-      }),
+      pushNote: jest.fn(),
       deleteNote: jest.fn().mockResolvedValue({ ok: true, value: undefined }),
     };
     const connectivity: Connectivity = { isOnline: () => true };
@@ -170,7 +146,7 @@ describe("hydrating repositories", () => {
       syncStateStore,
     );
 
-    // Initial save - this creates a pending upsert
+    // Save locally — creates pending upsert
     await repository.saveEnvelope({
       date: "05-01-2025",
       ciphertext: "content-v1",
@@ -179,32 +155,19 @@ describe("hydrating repositories", () => {
       updatedAt: "2025-01-05T10:00:00.000Z",
     });
 
-    // Set up a concurrent edit to happen during refreshEnvelope's push
-    saveEnvelopeDuringPush = async () => {
-      await repository.saveEnvelope({
-        date: "05-01-2025",
-        ciphertext: "content-v2",
-        nonce: "nonce-v2",
-        keyId: "key-1",
-        updatedAt: "2025-01-05T10:00:01.000Z",
-      });
-    };
-
-    // refreshEnvelope will call reconcileRemote which pushes since no remote exists
-    // During the push, v2 is saved
+    // refreshEnvelope fetches remote (null) — should keep local content
     await repository.refreshEnvelope("05-01-2025");
 
-    // The envelope should have v2 content (the edit made during push)
     const envelope = await repository.getEnvelope("05-01-2025");
-    expect(envelope?.ciphertext).toBe("content-v2");
-    expect(envelope?.nonce).toBe("nonce-v2");
+    expect(envelope?.ciphertext).toBe("content-v1");
+    expect(envelope?.nonce).toBe("nonce-v1");
 
-    // There should still be a pending op since v2 hasn't been synced yet
+    // pendingOp still set — push happens during sync, not refresh
     const hasPending = await repository.hasPendingOp("05-01-2025");
     expect(hasPending).toBe(true);
 
-    // Push should have been called once (for v1)
-    expect(pushCallCount).toBe(1);
+    // pushNote should NOT be called during refreshEnvelope
+    expect(gateway.pushNote).not.toHaveBeenCalled();
   });
 
   it("preserves pending edits made during sync", async () => {

--- a/src/__tests__/unifiedSyncedNoteRepository.test.ts
+++ b/src/__tests__/unifiedSyncedNoteRepository.test.ts
@@ -22,281 +22,581 @@ async function deleteUnifiedDb(): Promise<void> {
   );
 }
 
+function makeRemoteNote(overrides: Partial<{
+  id: string;
+  date: string;
+  ciphertext: string;
+  nonce: string;
+  keyId: string;
+  revision: number;
+  updatedAt: string;
+  serverUpdatedAt: string;
+  deleted: boolean;
+}> = {}) {
+  return {
+    id: "remote-1",
+    date: "10-01-2026",
+    ciphertext: "remote",
+    nonce: "nonce-remote",
+    keyId: "key-1",
+    revision: 1,
+    updatedAt: "2026-01-10T10:00:00.000Z",
+    serverUpdatedAt: "2026-01-10T10:00:00.000Z",
+    deleted: false,
+    ...overrides,
+  };
+}
+
+function makeGateway(overrides: Partial<RemoteNotesGateway> = {}): RemoteNotesGateway {
+  return {
+    fetchNoteByDate: jest.fn().mockResolvedValue({ ok: true, value: null }),
+    fetchNoteDates: jest.fn().mockResolvedValue({ ok: true, value: [] }),
+    fetchNotesSince: jest.fn().mockResolvedValue({ ok: true, value: [] }),
+    pushNote: jest.fn().mockResolvedValue({
+      ok: true,
+      value: makeRemoteNote({ revision: 1 }),
+    }),
+    deleteNote: jest.fn().mockResolvedValue({
+      ok: true,
+      value: makeRemoteNote({ deleted: true, revision: 2 }),
+    }),
+    ...overrides,
+  };
+}
+
+function makeDeps() {
+  const connectivity: Connectivity = { isOnline: () => true };
+  const clock: Clock = { now: () => new Date("2026-01-10T12:00:00.000Z") };
+  const syncStateStore: SyncStateStore = {
+    getState: jest.fn().mockResolvedValue({
+      ok: true,
+      value: { id: "state", cursor: null },
+    }),
+    setState: jest.fn().mockResolvedValue({ ok: true, value: undefined }),
+  };
+  return { connectivity, clock, syncStateStore };
+}
+
 describe("unifiedSyncedNoteRepository", () => {
   beforeEach(async () => {
     await deleteUnifiedDb();
   });
 
-  it("retries remote conflict by rebasing local revisions", async () => {
-    let pushCount = 0;
-    const gateway: RemoteNotesGateway = {
-      fetchNoteByDate: jest.fn().mockResolvedValue({
-        ok: true,
-        value: {
-          id: "remote-1",
-          date: "10-01-2026",
-          ciphertext: "remote",
-          nonce: "nonce-remote",
-          keyId: "key-1",
-          revision: 1,
-          updatedAt: "2026-01-10T10:00:00.000Z",
-          serverUpdatedAt: "2026-01-10T10:00:00.000Z",
-          deleted: false,
-        },
-      }),
-      fetchNoteDates: jest.fn().mockResolvedValue({ ok: true, value: [] }),
-      fetchNotesSince: jest.fn().mockResolvedValue({ ok: true, value: [] }),
-      pushNote: jest.fn().mockImplementation(async () => {
-        pushCount += 1;
-        if (pushCount === 1) {
-          return {
-            ok: false,
-            error: { type: "Conflict", message: "conflict" },
-          };
-        }
-        return {
+  describe("push with version gating", () => {
+    it("pushes new note with revision 0 (server assigns 1)", async () => {
+      const gateway = makeGateway({
+        pushNote: jest.fn().mockResolvedValue({
           ok: true,
-          value: {
-            id: "remote-1",
-            date: "10-01-2026",
-            ciphertext: "local",
-            nonce: "nonce-local",
-            keyId: "key-1",
-            revision: 2,
-            updatedAt: "2026-01-10T12:00:00.000Z",
-            serverUpdatedAt: "2026-01-10T12:00:00.000Z",
-            deleted: false,
-          },
-        };
-      }),
-      deleteNote: jest.fn().mockResolvedValue({ ok: true, value: undefined }),
-    };
-    const connectivity: Connectivity = { isOnline: () => true };
-    const clock: Clock = { now: () => new Date("2026-01-10T12:00:00.000Z") };
-    const syncStateStore: SyncStateStore = {
-      getState: jest.fn().mockResolvedValue({
-        ok: true,
-        value: { id: "state", cursor: null },
-      }),
-      setState: jest.fn().mockResolvedValue({ ok: true, value: undefined }),
-    };
+          value: makeRemoteNote({ ciphertext: "local", revision: 1 }),
+        }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
 
-    const repository = createUnifiedSyncedNoteEnvelopeRepository(
-      gateway,
-      "key-1",
-      async () => undefined,
-      connectivity,
-      clock,
-      syncStateStore,
-    );
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
 
-    await repository.saveEnvelope({
-      date: "10-01-2026",
-      ciphertext: "local",
-      nonce: "nonce-local",
-      keyId: "key-1",
-      updatedAt: "2026-01-10T12:00:00.000Z",
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "local",
+        nonce: "nonce-local",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T12:00:00.000Z",
+      });
+
+      await repo.sync();
+
+      // Should push with revision 0 (no serverRevision, no remoteId)
+      expect(gateway.pushNote).toHaveBeenCalledWith(
+        expect.objectContaining({ revision: 0 }),
+      );
+
+      const envelope = await repo.getEnvelope("10-01-2026");
+      expect(envelope?.revision).toBe(1);
     });
 
-    await repository.sync();
+    it("retries on VERSION_CONFLICT by fetching remote and pushing with updated revision", async () => {
+      let pushCount = 0;
+      const gateway = makeGateway({
+        fetchNoteByDate: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ revision: 3 }),
+        }),
+        pushNote: jest.fn().mockImplementation(async () => {
+          pushCount += 1;
+          if (pushCount === 1) {
+            return { ok: false, error: { type: "Conflict", message: "VERSION_CONFLICT" } };
+          }
+          return {
+            ok: true,
+            value: makeRemoteNote({ ciphertext: "local", revision: 4 }),
+          };
+        }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
 
-    const envelope = await repository.getEnvelope("10-01-2026");
-    expect(envelope?.revision).toBe(2);
-    expect(pushCount).toBe(2);
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "local",
+        nonce: "nonce-local",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T12:00:00.000Z",
+      });
+
+      await repo.sync();
+
+      expect(pushCount).toBe(2);
+      // Second push should use the remote's revision (3)
+      expect(gateway.pushNote).toHaveBeenLastCalledWith(
+        expect.objectContaining({ revision: 3, id: "remote-1" }),
+      );
+
+      const envelope = await repo.getEnvelope("10-01-2026");
+      expect(envelope?.revision).toBe(4);
+    });
+
+    it("leaves pendingOp if retry also fails", async () => {
+      const gateway = makeGateway({
+        fetchNoteByDate: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ revision: 3 }),
+        }),
+        pushNote: jest.fn().mockResolvedValue({
+          ok: false,
+          error: { type: "Conflict", message: "VERSION_CONFLICT" },
+        }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
+
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "local",
+        nonce: "nonce-local",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T12:00:00.000Z",
+      });
+
+      await repo.sync();
+
+      // pendingOp should still be set for next cycle
+      expect(await repo.hasPendingOp("10-01-2026")).toBe(true);
+    });
+  });
+
+  describe("delete with version gating", () => {
+    it("deletes with server revision check", async () => {
+      const gateway = makeGateway({
+        pushNote: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ revision: 1 }),
+        }),
+        deleteNote: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ deleted: true, revision: 2 }),
+        }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
+
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      // Save + sync to establish server link
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "local",
+        nonce: "nonce-local",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T12:00:00.000Z",
+      });
+      await repo.sync();
+
+      // Delete + sync
+      await repo.deleteEnvelope("10-01-2026");
+      await repo.sync();
+
+      expect(gateway.deleteNote).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "remote-1", revision: 1 }),
+      );
+
+      const envelope = await repo.getEnvelope("10-01-2026");
+      expect(envelope).toBeNull();
+    });
+
+    it("skips remote delete for never-synced notes", async () => {
+      const gateway = makeGateway();
+      const { connectivity, clock, syncStateStore } = makeDeps();
+
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "local",
+        nonce: "nonce-local",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T12:00:00.000Z",
+      });
+
+      // Delete before ever syncing
+      await repo.deleteEnvelope("10-01-2026");
+      await repo.sync();
+
+      expect(gateway.deleteNote).not.toHaveBeenCalled();
+      const envelope = await repo.getEnvelope("10-01-2026");
+      expect(envelope).toBeNull();
+    });
+
+    it("cancels local delete if remote has new content on conflict", async () => {
+      const remoteNote = makeRemoteNote({ ciphertext: "remote-new", revision: 5 });
+      const gateway = makeGateway({
+        pushNote: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ revision: 1 }),
+        }),
+        deleteNote: jest.fn().mockResolvedValue({
+          ok: false,
+          error: { type: "Conflict", message: "VERSION_CONFLICT" },
+        }),
+        fetchNoteByDate: jest.fn().mockResolvedValue({
+          ok: true,
+          value: remoteNote,
+        }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
+
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      // Save + sync to establish link
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "local",
+        nonce: "nonce-local",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T12:00:00.000Z",
+      });
+      await repo.sync();
+
+      // Delete
+      await repo.deleteEnvelope("10-01-2026");
+      await repo.sync();
+
+      // Should accept remote content instead of deleting
+      const envelope = await repo.getEnvelope("10-01-2026");
+      expect(envelope?.ciphertext).toBe("remote-new");
+    });
+  });
+
+  describe("pull (applyRemoteUpdate)", () => {
+    it("skips remote update when local delete is pending", async () => {
+      const gateway = makeGateway({
+        pushNote: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ revision: 1 }),
+        }),
+        deleteNote: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ deleted: true, revision: 2 }),
+        }),
+        fetchNotesSince: jest.fn().mockResolvedValue({
+          ok: true,
+          value: [makeRemoteNote({ revision: 3, ciphertext: "remote-updated" })],
+        }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
+
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      // Save + sync to establish link, then delete locally
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "local",
+        nonce: "nonce-local",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T12:00:00.000Z",
+      });
+      await repo.sync();
+      await repo.deleteEnvelope("10-01-2026");
+
+      // Sync again — should push delete, not accept remote update
+      await repo.sync();
+      expect(gateway.deleteNote).toHaveBeenCalled();
+    });
+
+    it("keeps local content when remote deleted but local has pending upsert", async () => {
+      // Push always conflicts so pendingOp stays "upsert" through pull phase
+      const gateway = makeGateway({
+        pushNote: jest.fn().mockResolvedValue({
+          ok: false,
+          error: { type: "Conflict", message: "VERSION_CONFLICT" },
+        }),
+        fetchNoteByDate: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ deleted: true, revision: 2 }),
+        }),
+        fetchNotesSince: jest.fn().mockResolvedValue({
+          ok: true,
+          value: [makeRemoteNote({ deleted: true, revision: 2 })],
+        }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
+
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "local-edit",
+        nonce: "nonce-local",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T12:00:00.000Z",
+      });
+
+      // Push conflicts (pendingOp stays), pull sees deleted remote → keeps local
+      await repo.sync();
+
+      const envelope = await repo.getEnvelope("10-01-2026");
+      expect(envelope?.ciphertext).toBe("local-edit");
+    });
+
+    it("accepts remote content when no local pending", async () => {
+      const gateway = makeGateway({
+        fetchNotesSince: jest.fn().mockResolvedValue({
+          ok: true,
+          value: [makeRemoteNote({ ciphertext: "from-server", revision: 5 })],
+        }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
+
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      await repo.sync();
+
+      const envelope = await repo.getEnvelope("10-01-2026");
+      expect(envelope?.ciphertext).toBe("from-server");
+      expect(envelope?.revision).toBe(5);
+    });
+
+    it("keeps local content on remote update when local upsert is pending", async () => {
+      let pushCount = 0;
+      const gateway = makeGateway({
+        pushNote: jest.fn().mockImplementation(async () => {
+          pushCount++;
+          if (pushCount === 1) {
+            // First push succeeds (initial sync)
+            return {
+              ok: true,
+              value: makeRemoteNote({ ciphertext: "local", revision: 1 }),
+            };
+          }
+          // Second push conflicts — pendingOp stays "upsert" during pull
+          return {
+            ok: false,
+            error: { type: "Conflict", message: "VERSION_CONFLICT" },
+          };
+        }),
+        fetchNoteByDate: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ ciphertext: "remote-v2", revision: 2 }),
+        }),
+        fetchNotesSince: jest
+          .fn()
+          .mockResolvedValueOnce({ ok: true, value: [] })
+          .mockResolvedValueOnce({
+            ok: true,
+            value: [makeRemoteNote({ ciphertext: "remote-v2", revision: 2, serverUpdatedAt: "2026-01-10T11:00:00.000Z" })],
+          }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
+
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      // Save + sync to establish link
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "local",
+        nonce: "nonce-local",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T12:00:00.000Z",
+      });
+      await repo.sync();
+
+      // Make a new local edit, then sync again
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "local-v2",
+        nonce: "nonce-local-2",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T13:00:00.000Z",
+      });
+
+      // Second sync: push conflicts (pendingOp stays), pull has remote-v2
+      await repo.sync();
+
+      const envelope = await repo.getEnvelope("10-01-2026");
+      // Local content preserved (pending upsert takes priority over remote pull)
+      expect(envelope?.ciphertext).toBe("local-v2");
+    });
+  });
+
+  describe("refreshEnvelope", () => {
+    it("accepts remote content when no local pending", async () => {
+      const gateway = makeGateway({
+        fetchNoteByDate: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ ciphertext: "from-server", revision: 3 }),
+        }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
+
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      const envelope = await repo.refreshEnvelope("10-01-2026");
+      expect(envelope?.ciphertext).toBe("from-server");
+      expect(envelope?.revision).toBe(3);
+    });
+
+    it("keeps local content when pending upsert exists", async () => {
+      const gateway = makeGateway({
+        fetchNoteByDate: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ ciphertext: "remote-v5", revision: 5 }),
+        }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
+
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "local-edit",
+        nonce: "nonce-local",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T12:00:00.000Z",
+      });
+
+      const envelope = await repo.refreshEnvelope("10-01-2026");
+      expect(envelope?.ciphertext).toBe("local-edit");
+    });
+
+    it("deletes locally when remote deleted and no local pending", async () => {
+      const gateway = makeGateway({
+        pushNote: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ revision: 1 }),
+        }),
+        fetchNoteByDate: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ deleted: true, revision: 2 }),
+        }),
+        fetchNotesSince: jest.fn().mockResolvedValue({ ok: true, value: [] }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
+
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      // Save + sync to establish link (no pending after sync)
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "local",
+        nonce: "nonce-local",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T12:00:00.000Z",
+      });
+      await repo.sync();
+
+      // Refresh finds remote deleted
+      const envelope = await repo.refreshEnvelope("10-01-2026");
+      expect(envelope).toBeNull();
+    });
+  });
+
+  describe("serverRevision tracking", () => {
+    it("preserves serverRevision across local saves", async () => {
+      const gateway = makeGateway({
+        pushNote: jest.fn().mockResolvedValue({
+          ok: true,
+          value: makeRemoteNote({ revision: 1 }),
+        }),
+        fetchNotesSince: jest.fn().mockResolvedValue({ ok: true, value: [] }),
+      });
+      const { connectivity, clock, syncStateStore } = makeDeps();
+
+      const repo = createUnifiedSyncedNoteEnvelopeRepository(
+        gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
+      );
+
+      // Save + sync → serverRevision = 1
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "v1",
+        nonce: "nonce-1",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T12:00:00.000Z",
+      });
+      await repo.sync();
+
+      // Local edit → should push with serverRevision 1 on next sync
+      await repo.saveEnvelope({
+        date: "10-01-2026",
+        ciphertext: "v2",
+        nonce: "nonce-2",
+        keyId: "key-1",
+        updatedAt: "2026-01-10T13:00:00.000Z",
+      });
+
+      // Reset mock to capture next push call
+      (gateway.pushNote as jest.Mock).mockResolvedValue({
+        ok: true,
+        value: makeRemoteNote({ ciphertext: "v2", revision: 2 }),
+      });
+
+      await repo.sync();
+
+      // Second push should use serverRevision 1 (not local revision)
+      expect(gateway.pushNote).toHaveBeenLastCalledWith(
+        expect.objectContaining({ revision: 1 }),
+      );
+    });
   });
 
   it("deduplicates refreshDates calls", async () => {
-    const gateway: RemoteNotesGateway = {
-      fetchNoteByDate: jest.fn().mockResolvedValue({ ok: true, value: null }),
-      fetchNoteDates: jest.fn().mockResolvedValue({ ok: true, value: [] }),
-      fetchNotesSince: jest.fn().mockResolvedValue({ ok: true, value: [] }),
-      pushNote: jest.fn().mockResolvedValue({
-        ok: true,
-        value: {
-          id: "remote-1",
-          date: "10-01-2026",
-          ciphertext: "local",
-          nonce: "nonce-local",
-          keyId: "key-1",
-          revision: 1,
-          updatedAt: "2026-01-10T12:00:00.000Z",
-          serverUpdatedAt: "2026-01-10T12:00:00.000Z",
-          deleted: false,
-        },
-      }),
-      deleteNote: jest.fn().mockResolvedValue({ ok: true, value: undefined }),
-    };
-    const connectivity: Connectivity = { isOnline: () => true };
-    const clock: Clock = { now: () => new Date("2026-01-10T12:00:00.000Z") };
-    const syncStateStore: SyncStateStore = {
-      getState: jest.fn().mockResolvedValue({
-        ok: true,
-        value: { id: "state", cursor: null },
-      }),
-      setState: jest.fn().mockResolvedValue({ ok: true, value: undefined }),
-    };
+    const gateway = makeGateway();
+    const { connectivity, clock, syncStateStore } = makeDeps();
 
-    const repository = createUnifiedSyncedNoteEnvelopeRepository(
-      gateway,
-      "key-1",
-      async () => undefined,
-      connectivity,
-      clock,
-      syncStateStore,
+    const repo = createUnifiedSyncedNoteEnvelopeRepository(
+      gateway, "key-1", async () => undefined, connectivity, clock, syncStateStore,
     );
 
     await Promise.all([
-      repository.refreshDates(2026),
-      repository.refreshDates(2026),
+      repo.refreshDates(2026),
+      repo.refreshDates(2026),
     ]);
 
     expect(gateway.fetchNoteDates).toHaveBeenCalledTimes(1);
-  });
-
-  it("keeps newer local edits when remote has higher revision after local reset", async () => {
-    const gateway: RemoteNotesGateway = {
-      fetchNoteByDate: jest.fn().mockResolvedValue({
-        ok: true,
-        value: {
-          id: "remote-1",
-          date: "10-01-2026",
-          ciphertext: "remote",
-          nonce: "nonce-remote",
-          keyId: "key-1",
-          revision: 5,
-          updatedAt: "2026-01-10T10:00:00.000Z",
-          serverUpdatedAt: "2026-01-10T10:00:00.000Z",
-          deleted: false,
-        },
-      }),
-      fetchNoteDates: jest.fn().mockResolvedValue({ ok: true, value: [] }),
-      fetchNotesSince: jest.fn().mockResolvedValue({ ok: true, value: [] }),
-      pushNote: jest.fn().mockResolvedValue({
-        ok: true,
-        value: {
-          id: "remote-1",
-          date: "10-01-2026",
-          ciphertext: "local",
-          nonce: "nonce-local",
-          keyId: "key-1",
-          revision: 6,
-          updatedAt: "2026-01-10T12:00:00.000Z",
-          serverUpdatedAt: "2026-01-10T12:00:00.000Z",
-          deleted: false,
-        },
-      }),
-      deleteNote: jest.fn().mockResolvedValue({ ok: true, value: undefined }),
-    };
-    const connectivity: Connectivity = { isOnline: () => true };
-    const clock: Clock = { now: () => new Date("2026-01-10T12:00:00.000Z") };
-    const syncStateStore: SyncStateStore = {
-      getState: jest.fn().mockResolvedValue({
-        ok: true,
-        value: { id: "state", cursor: null },
-      }),
-      setState: jest.fn().mockResolvedValue({ ok: true, value: undefined }),
-    };
-
-    const repository = createUnifiedSyncedNoteEnvelopeRepository(
-      gateway,
-      "key-1",
-      async () => undefined,
-      connectivity,
-      clock,
-      syncStateStore,
-    );
-
-    await repository.saveEnvelope({
-      date: "10-01-2026",
-      ciphertext: "local",
-      nonce: "nonce-local",
-      keyId: "key-1",
-      updatedAt: "2026-01-10T12:00:00.000Z",
-    });
-
-    await repository.refreshEnvelope("10-01-2026");
-
-    const envelope = await repository.getEnvelope("10-01-2026");
-    expect(envelope?.ciphertext).toBe("local");
-    expect(gateway.pushNote).toHaveBeenCalledTimes(1);
-  });
-
-  it("preserves re-created notes after delete even if remote revision is higher", async () => {
-    let pushCount = 0;
-    const remoteNote = {
-      id: "remote-1",
-      date: "10-01-2026",
-      ciphertext: "remote-old",
-      nonce: "nonce-remote",
-      keyId: "key-1",
-      revision: 5,
-      updatedAt: "2026-01-10T10:00:00.000Z",
-      serverUpdatedAt: "2026-01-10T10:00:00.000Z",
-      deleted: false,
-    };
-
-    const gateway: RemoteNotesGateway = {
-      fetchNoteByDate: jest.fn().mockResolvedValue({
-        ok: true,
-        value: remoteNote,
-      }),
-      fetchNoteDates: jest.fn().mockResolvedValue({ ok: true, value: [] }),
-      fetchNotesSince: jest.fn().mockResolvedValue({ ok: true, value: [] }),
-      pushNote: jest.fn().mockImplementation(async () => {
-        pushCount += 1;
-        if (pushCount === 1) {
-          return {
-            ok: false,
-            error: { type: "Conflict", message: "conflict" },
-          };
-        }
-        return {
-          ok: true,
-          value: {
-            ...remoteNote,
-            ciphertext: "local-new",
-            nonce: "nonce-local",
-            revision: 6,
-            updatedAt: "2026-01-10T12:00:00.000Z",
-            serverUpdatedAt: "2026-01-10T12:00:00.000Z",
-          },
-        };
-      }),
-      deleteNote: jest.fn().mockResolvedValue({ ok: true, value: undefined }),
-    };
-    const connectivity: Connectivity = { isOnline: () => true };
-    const clock: Clock = { now: () => new Date("2026-01-10T12:00:00.000Z") };
-    const syncStateStore: SyncStateStore = {
-      getState: jest.fn().mockResolvedValue({
-        ok: true,
-        value: { id: "state", cursor: null },
-      }),
-      setState: jest.fn().mockResolvedValue({ ok: true, value: undefined }),
-    };
-
-    const repository = createUnifiedSyncedNoteEnvelopeRepository(
-      gateway,
-      "key-1",
-      async () => undefined,
-      connectivity,
-      clock,
-      syncStateStore,
-    );
-
-    await repository.refreshEnvelope("10-01-2026");
-    await repository.deleteEnvelope("10-01-2026");
-    await repository.saveEnvelope({
-      date: "10-01-2026",
-      ciphertext: "local-new",
-      nonce: "nonce-local",
-      keyId: "key-1",
-      updatedAt: "2026-01-10T12:00:00.000Z",
-    });
-
-    await repository.refreshEnvelope("10-01-2026");
-
-    const envelope = await repository.getEnvelope("10-01-2026");
-    expect(envelope?.ciphertext).toBe("local-new");
-    expect(pushCount).toBe(2);
   });
 });

--- a/src/domain/sync/remoteNotesGateway.ts
+++ b/src/domain/sync/remoteNotesGateway.ts
@@ -21,7 +21,6 @@ export interface RemoteNotePayload {
   keyId: string;
   revision: number;
   updatedAt: string;
-  serverUpdatedAt?: string | null;
   deleted: boolean;
 }
 
@@ -35,6 +34,6 @@ export interface RemoteNotesGateway {
   ): Promise<Result<RemoteNote[], SyncError>>;
   pushNote(note: RemoteNotePayload): Promise<Result<RemoteNote, SyncError>>;
   deleteNote(
-    options: { id?: string | null; date: string },
-  ): Promise<Result<void, SyncError>>;
+    options: { id: string; date: string; revision: number },
+  ): Promise<Result<RemoteNote, SyncError>>;
 }

--- a/src/storage/remoteNotesGateway.ts
+++ b/src/storage/remoteNotesGateway.ts
@@ -44,13 +44,18 @@ function toSyncError(
   return { type: fallback, message: "Remote request failed." };
 }
 
-function isConflictError(error: unknown): boolean {
+function isVersionConflict(error: unknown): boolean {
   if (error && typeof error === "object") {
-    const record = error as { code?: string; status?: number };
-    if (record.code === "23505" || record.code === "PGRST116") {
+    const record = error as { code?: string; message?: string };
+    // P0002 = custom raise from push_note/delete_note
+    // 23505 = unique constraint violation on insert
+    if (record.code === "P0002" || record.code === "23505") {
       return true;
     }
-    if (record.status === 404 || record.status === 406 || record.status === 409) {
+    if (
+      typeof record.message === "string" &&
+      record.message.includes("VERSION_CONFLICT")
+    ) {
       return true;
     }
   }
@@ -137,57 +142,22 @@ async function pushRemoteNote(
   userId: string,
   note: RemoteNotePayload,
 ): Promise<Result<RemoteNote, SyncError>> {
-  const payload = {
-    user_id: userId,
-    date: note.date,
-    ciphertext: note.ciphertext,
-    nonce: note.nonce,
-    key_id: note.keyId,
-    revision: note.revision,
-    updated_at: note.updatedAt,
-    deleted: note.deleted,
-  };
-
-  if (note.id) {
-    try {
-      let query = supabase
-        .from("notes")
-        .update(payload)
-        .eq("id", note.id)
-        .eq("user_id", userId);
-
-      if (note.serverUpdatedAt) {
-        query = query.eq("server_updated_at", note.serverUpdatedAt);
-      } else {
-        query = query.is("server_updated_at", null);
-      }
-
-      const { data, error } = await query.select().maybeSingle();
-      if (error) {
-        if (isConflictError(error)) {
-          return err({ type: "Conflict", message: "Revision conflict." });
-        }
-        return err(toSyncError(error, "RemoteRejected"));
-      }
-      if (!data) {
-        return err({ type: "Conflict", message: "Revision conflict." });
-      }
-      return ok(mapRemoteRow(data as RemoteNoteRow));
-    } catch (error) {
-      return err(toSyncError(error));
-    }
-  }
-
   try {
-    const { data, error } = await supabase
-      .from("notes")
-      .insert(payload)
-      .select()
-      .single();
+    const { data, error } = await supabase.rpc("push_note", {
+      p_id: note.id ?? null,
+      p_user_id: userId,
+      p_date: note.date,
+      p_key_id: note.keyId,
+      p_ciphertext: note.ciphertext,
+      p_nonce: note.nonce,
+      p_revision: note.revision,
+      p_updated_at: note.updatedAt,
+      p_deleted: note.deleted,
+    });
 
     if (error) {
-      if (isConflictError(error)) {
-        return err({ type: "Conflict", message: "Revision conflict." });
+      if (isVersionConflict(error)) {
+        return err({ type: "Conflict", message: "Version conflict." });
       }
       return err(toSyncError(error, "RemoteRejected"));
     }
@@ -200,24 +170,22 @@ async function pushRemoteNote(
 async function deleteRemoteNote(
   supabase: SupabaseClient,
   userId: string,
-  options: { id?: string | null; date: string },
-): Promise<Result<void, SyncError>> {
+  options: { id: string; date: string; revision: number },
+): Promise<Result<RemoteNote, SyncError>> {
   try {
-    let query = supabase
-      .from("notes")
-      .update({ deleted: true })
-      .eq("user_id", userId)
-      .eq("date", options.date);
+    const { data, error } = await supabase.rpc("delete_note", {
+      p_id: options.id,
+      p_user_id: userId,
+      p_revision: options.revision,
+    });
 
-    if (options.id) {
-      query = query.eq("id", options.id);
-    }
-
-    const { error } = await query;
     if (error) {
+      if (isVersionConflict(error)) {
+        return err({ type: "Conflict", message: "Version conflict." });
+      }
       return err(toSyncError(error, "RemoteRejected"));
     }
-    return ok(undefined);
+    return ok(mapRemoteRow(data as RemoteNoteRow));
   } catch (error) {
     return err(toSyncError(error));
   }

--- a/src/storage/unifiedDb.ts
+++ b/src/storage/unifiedDb.ts
@@ -22,6 +22,7 @@ export interface NoteRecord {
 export interface NoteMetaRecord {
   date: string;
   revision: number;
+  serverRevision?: number;
   remoteId?: string | null;
   serverUpdatedAt?: string | null;
   lastSyncedAt?: string | null;

--- a/src/storage/unifiedSyncedNoteRepository.ts
+++ b/src/storage/unifiedSyncedNoteRepository.ts
@@ -70,11 +70,16 @@ function toLocalMeta(remote: RemoteNote, now: string): NoteMetaRecord {
   return {
     date: remote.date,
     revision: remote.revision,
+    serverRevision: remote.revision,
     remoteId: remote.id,
     serverUpdatedAt: remote.serverUpdatedAt,
     lastSyncedAt: now,
     pendingOp: null,
   };
+}
+
+function expectedServerRevision(meta: NoteMetaRecord): number {
+  return meta.serverRevision ?? (meta.remoteId ? meta.revision : 0);
 }
 
 function isSyncError(error: unknown): error is SyncError {
@@ -100,78 +105,6 @@ function toUnknownSyncError(error: unknown): SyncError {
   return { type: "Unknown", message: "Sync failed." };
 }
 
-interface ConflictResolutionContext {
-  gateway: RemoteNotesGateway;
-  activeKeyId: string;
-  localRecord: NoteRecord;
-  localMeta: NoteMetaRecord;
-  remote: RemoteNote;
-}
-
-async function resolveConflict(
-  ctx: ConflictResolutionContext,
-): Promise<RemoteNote> {
-  const { gateway, activeKeyId, localRecord, localMeta, remote } = ctx;
-  const localRevision = localMeta.revision;
-  const remoteRevision = remote.revision;
-  const localUpdatedAt = new Date(localRecord.updatedAt).getTime();
-  const remoteUpdatedAt = new Date(remote.updatedAt).getTime();
-  const hasRemoteLink =
-    localMeta.remoteId != null || localMeta.serverUpdatedAt != null;
-  const isFreshLocal = !hasRemoteLink;
-  const hasUnsyncedEdits = localMeta.pendingOp === "upsert";
-
-  // Determine winner: higher revision wins, tie-break by timestamp
-  const localWins =
-    localRevision > remoteRevision ||
-    (localRevision === remoteRevision &&
-      localUpdatedAt >= remoteUpdatedAt) ||
-    (isFreshLocal && localUpdatedAt >= remoteUpdatedAt) ||
-    (hasUnsyncedEdits && localUpdatedAt >= remoteUpdatedAt);
-
-  if (!localWins) {
-    return remote;
-  }
-
-  // Local wins - try to push with rebased revision
-  try {
-    const rebasedRevision =
-      localRevision > remoteRevision ? localRevision : remoteRevision + 1;
-
-    const pushed = await gateway.pushNote({
-      id: localMeta.remoteId ?? remote.id,
-      date: localRecord.date,
-      ciphertext: localRecord.ciphertext,
-      nonce: localRecord.nonce,
-      keyId: localRecord.keyId ?? activeKeyId,
-      revision: rebasedRevision,
-      updatedAt: localRecord.updatedAt,
-      serverUpdatedAt: remote.serverUpdatedAt,
-      deleted: false,
-    });
-    return unwrapOrThrow(pushed);
-  } catch (rebaseError) {
-    // Rebased push failed, accept remote version as fallback
-    console.warn("Rebased push failed, accepting remote version:", rebaseError);
-    return remote;
-  }
-}
-
-function localWinsRemote(
-  localRecord: NoteRecord,
-  localMeta: NoteMetaRecord,
-  remote: RemoteNote,
-): boolean {
-  const localRevision = localMeta.revision;
-  const remoteRevision = remote.revision;
-  return (
-    localRevision > remoteRevision ||
-    (localRevision === remoteRevision &&
-      new Date(localRecord.updatedAt).getTime() >=
-        new Date(remote.updatedAt).getTime())
-  );
-}
-
 export function createUnifiedSyncedNoteEnvelopeRepository(
   gateway: RemoteNotesGateway,
   activeKeyId: string,
@@ -188,6 +121,183 @@ export function createUnifiedSyncedNoteEnvelopeRepository(
     listeners.forEach((cb) => cb(status));
   };
 
+  const pushUpsert = async (
+    record: NoteRecord,
+    meta: NoteMetaRecord,
+  ): Promise<void> => {
+    const serverRev = expectedServerRevision(meta);
+
+    const pushed = await gateway.pushNote({
+      id: meta.remoteId,
+      date: record.date,
+      ciphertext: record.ciphertext,
+      nonce: record.nonce,
+      keyId: record.keyId ?? activeKeyId,
+      revision: serverRev,
+      updatedAt: record.updatedAt,
+      deleted: false,
+    });
+
+    if (pushed.ok) {
+      await applyPushSuccess(record.date, meta, pushed.value);
+      return;
+    }
+
+    if (pushed.error.type !== "Conflict") {
+      throw pushed.error;
+    }
+
+    // Conflict: fetch remote, update metadata, retry once
+    const remoteResult = await gateway.fetchNoteByDate(record.date);
+    const remote = unwrapOrThrow(remoteResult);
+
+    if (remote) {
+      // Update meta with fresh server state, then retry
+      const updatedMeta: NoteMetaRecord = {
+        ...meta,
+        remoteId: remote.id,
+        serverRevision: remote.revision,
+        serverUpdatedAt: remote.serverUpdatedAt,
+      };
+      await setNoteMeta(updatedMeta);
+
+      const retry = await gateway.pushNote({
+        id: remote.id,
+        date: record.date,
+        ciphertext: record.ciphertext,
+        nonce: record.nonce,
+        keyId: record.keyId ?? activeKeyId,
+        revision: remote.revision,
+        updatedAt: record.updatedAt,
+        deleted: false,
+      });
+
+      if (retry.ok) {
+        await applyPushSuccess(record.date, updatedMeta, retry.value);
+        return;
+      }
+    }
+
+    // Retry failed or no remote — leave pendingOp for next cycle
+  };
+
+  const applyPushSuccess = async (
+    date: string,
+    originalMeta: NoteMetaRecord,
+    remote: RemoteNote,
+  ): Promise<void> => {
+    const now = clock.now().toISOString();
+    const currentMeta = (await getNoteEnvelopeState(date)).meta;
+    const newEditsOccurred =
+      currentMeta && currentMeta.revision > originalMeta.revision;
+
+    if (newEditsOccurred) {
+      // New edits during sync — only update server metadata, keep pendingOp
+      await setNoteMeta({
+        ...currentMeta,
+        remoteId: remote.id,
+        serverRevision: remote.revision,
+        serverUpdatedAt: remote.serverUpdatedAt,
+      });
+    } else {
+      await setNoteAndMeta(toLocalRecord(remote), toLocalMeta(remote, now));
+    }
+  };
+
+  const pushDelete = async (meta: NoteMetaRecord): Promise<void> => {
+    if (!meta.remoteId) {
+      // Never synced — just delete locally
+      await deleteNoteAndMeta(meta.date);
+      await deleteRemoteDate(meta.date);
+      return;
+    }
+
+    const serverRev = expectedServerRevision(meta);
+
+    const deleted = await gateway.deleteNote({
+      id: meta.remoteId,
+      date: meta.date,
+      revision: serverRev,
+    });
+
+    if (deleted.ok) {
+      await deleteNoteAndMeta(meta.date);
+      await deleteRemoteDate(meta.date);
+      return;
+    }
+
+    if (deleted.error.type !== "Conflict") {
+      throw deleted.error;
+    }
+
+    // Conflict on delete: fetch remote to see current state
+    const remoteResult = await gateway.fetchNoteByDate(meta.date);
+    const remote = unwrapOrThrow(remoteResult);
+
+    if (!remote || remote.deleted) {
+      // Remote already deleted or gone — clean up locally
+      await deleteNoteAndMeta(meta.date);
+      await deleteRemoteDate(meta.date);
+      return;
+    }
+
+    // Remote exists and not deleted — cancel our delete, accept remote content
+    const now = clock.now().toISOString();
+    await setNoteAndMeta(toLocalRecord(remote), toLocalMeta(remote, now));
+  };
+
+  const applyRemoteUpdate = async (remote: RemoteNote): Promise<void> => {
+    const state = await getNoteEnvelopeState(remote.date);
+    const localRecord = state.record;
+    const localMeta = state.meta;
+
+    // Local delete pending — skip, will be pushed next
+    if (localMeta?.pendingOp === "delete") {
+      return;
+    }
+
+    // Already synced to this version, no local pending
+    if (
+      localMeta?.serverUpdatedAt === remote.serverUpdatedAt &&
+      !localMeta?.pendingOp
+    ) {
+      return;
+    }
+
+    const now = clock.now().toISOString();
+
+    if (remote.deleted) {
+      if (localMeta?.pendingOp === "upsert" && localRecord) {
+        // Local edit pending — keep local content, update server metadata only
+        await setNoteMeta({
+          ...localMeta,
+          remoteId: remote.id,
+          serverRevision: remote.revision,
+          serverUpdatedAt: remote.serverUpdatedAt,
+        });
+        return;
+      }
+      // No local pending — accept deletion
+      await deleteNoteAndMeta(remote.date);
+      await deleteRemoteDate(remote.date);
+      return;
+    }
+
+    if (localMeta?.pendingOp === "upsert" && localRecord) {
+      // Local edit pending — keep local content, update server metadata only
+      await setNoteMeta({
+        ...localMeta,
+        remoteId: remote.id,
+        serverRevision: remote.revision,
+        serverUpdatedAt: remote.serverUpdatedAt,
+      });
+      return;
+    }
+
+    // No local pending — accept remote content
+    await setNoteAndMeta(toLocalRecord(remote), toLocalMeta(remote, now));
+  };
+
   const sync = async (): Promise<Result<SyncStatus, SyncError>> => {
     if (!connectivity.isOnline()) {
       setSyncStatus(SyncStatus.Offline);
@@ -199,84 +309,24 @@ export function createUnifiedSyncedNoteEnvelopeRepository(
     try {
       const states = await getAllNoteEnvelopeStates();
 
-      // Push pending local changes.
+      // Push pending local changes
       for (const state of states) {
         const meta = state.meta;
         if (!meta?.pendingOp) continue;
         const record = state.record;
-        const now = clock.now().toISOString();
 
         if (meta.pendingOp === "delete") {
-          const deleted = await gateway.deleteNote({
-            id: meta.remoteId ?? undefined,
-            date: meta.date,
-          });
-          unwrapOrThrow(deleted);
-          await deleteRemoteDate(meta.date);
-          await deleteNoteAndMeta(meta.date);
+          await pushDelete(meta);
           continue;
         }
 
         if (!record) continue;
-
-        const pushed = await gateway.pushNote({
-          id: meta.remoteId,
-          date: record.date,
-          ciphertext: record.ciphertext,
-          nonce: record.nonce,
-          keyId: record.keyId ?? activeKeyId,
-          revision: meta.revision,
-          updatedAt: record.updatedAt,
-          serverUpdatedAt: meta.serverUpdatedAt ?? null,
-          deleted: false,
-        });
-
-        if (pushed.ok) {
-          // Re-read current meta to check if new edits happened during sync
-          const currentMeta = (await getNoteEnvelopeState(record.date)).meta;
-          const newEditsOccurred =
-            currentMeta && currentMeta.revision > meta.revision;
-
-          if (newEditsOccurred) {
-            // New edits happened during sync - only update server metadata,
-            // keep local content and pendingOp for next sync
-            await setNoteMeta({
-              ...currentMeta,
-              remoteId: pushed.value.id,
-              serverUpdatedAt: pushed.value.serverUpdatedAt,
-            });
-          } else {
-            // No new edits - safe to overwrite with pushed content
-            await setNoteAndMeta(toLocalRecord(pushed.value), {
-              ...toLocalMeta(pushed.value, now),
-              lastSyncedAt: now,
-            });
-          }
-        } else if (pushed.error.type === "Conflict") {
-          const remoteResult = await gateway.fetchNoteByDate(record.date);
-          const remote = unwrapOrThrow(remoteResult);
-          if (!remote) {
-            throw { type: "Conflict", message: "Remote note missing." };
-          }
-
-          const resolved = await resolveConflict({
-            gateway,
-            activeKeyId,
-            localRecord: record,
-            localMeta: meta,
-            remote,
-          });
-          await setNoteAndMeta(toLocalRecord(resolved), {
-            ...toLocalMeta(resolved, now),
-            lastSyncedAt: now,
-          });
-        } else {
-          throw pushed.error;
-        }
+        await pushUpsert(record, meta);
       }
 
       await syncImages();
 
+      // Pull remote updates
       const syncStateResult = await syncStateStore.getState();
       const syncState = unwrapOrThrow(syncStateResult);
       const remoteUpdatesResult = await gateway.fetchNotesSince(
@@ -363,278 +413,6 @@ export function createUnifiedSyncedNoteEnvelopeRepository(
     return { record, meta, envelope };
   };
 
-  const pushLocal = async (
-    record: NoteRecord,
-    meta: NoteMetaRecord,
-  ): Promise<RemoteNote | null> => {
-    const pushed = await gateway.pushNote({
-      id: meta.remoteId,
-      date: record.date,
-      ciphertext: record.ciphertext,
-      nonce: record.nonce,
-      keyId: record.keyId ?? activeKeyId,
-      revision: meta.revision,
-      updatedAt: record.updatedAt,
-      serverUpdatedAt: meta.serverUpdatedAt ?? null,
-      deleted: false,
-    });
-
-    if (pushed.ok) {
-      return pushed.value;
-    }
-
-    if (pushed.error.type !== "Conflict") {
-      throw new Error(pushed.error.message);
-    }
-
-    const remoteResult = await gateway.fetchNoteByDate(record.date);
-    const remote = unwrapOrThrow(remoteResult);
-    if (!remote) {
-      return null;
-    }
-
-    return await resolveConflict({
-      gateway,
-      activeKeyId,
-      localRecord: record,
-      localMeta: meta,
-      remote,
-    });
-  };
-
-  const applyRemoteUpdate = async (remote: RemoteNote): Promise<void> => {
-    const state = await getNoteEnvelopeState(remote.date);
-    const localRecord = state.record;
-    const localMeta = state.meta;
-
-    const meta: NoteMetaRecord | null =
-      localMeta ??
-      (localRecord
-        ? {
-            date: remote.date,
-            revision: 1,
-            remoteId: null,
-            serverUpdatedAt: null,
-            lastSyncedAt: null,
-            pendingOp: "upsert",
-          }
-        : null);
-
-    if (meta?.pendingOp === "delete") {
-      return;
-    }
-
-    if (remote.deleted) {
-      if (!localRecord || !meta) {
-        await deleteNoteAndMeta(remote.date);
-        await deleteRemoteDate(remote.date);
-        return;
-      }
-
-      const shouldPushLocal =
-        meta.pendingOp === "upsert" ||
-        localWinsRemote(localRecord, meta, remote);
-      if (shouldPushLocal) {
-        const pushed = await pushLocal(localRecord, meta);
-        if (pushed?.deleted) {
-          await deleteNoteAndMeta(remote.date);
-          await deleteRemoteDate(remote.date);
-          return;
-        }
-        if (pushed) {
-          await setNoteAndMeta(
-            toLocalRecord(pushed),
-            toLocalMeta(pushed, clock.now().toISOString()),
-          );
-        }
-        return;
-      }
-
-      await deleteNoteAndMeta(remote.date);
-      await deleteRemoteDate(remote.date);
-      return;
-    }
-
-    if (!localRecord || !meta) {
-      await setNoteAndMeta(
-        toLocalRecord(remote),
-        toLocalMeta(remote, clock.now().toISOString()),
-      );
-      return;
-    }
-
-    if (meta.serverUpdatedAt === remote.serverUpdatedAt && !meta.pendingOp) {
-      return;
-    }
-
-    if (meta.pendingOp === "upsert") {
-      const pushed = await pushLocal(localRecord, meta);
-      if (pushed?.deleted) {
-        await deleteNoteAndMeta(remote.date);
-        await deleteRemoteDate(remote.date);
-        return;
-      }
-      if (pushed) {
-        await setNoteAndMeta(
-          toLocalRecord(pushed),
-          toLocalMeta(pushed, clock.now().toISOString()),
-        );
-      }
-      return;
-    }
-
-    const resolved = await resolveConflict({
-      gateway,
-      activeKeyId,
-      localRecord,
-      localMeta: meta,
-      remote,
-    });
-
-    if (resolved.deleted) {
-      await deleteNoteAndMeta(remote.date);
-      await deleteRemoteDate(remote.date);
-      return;
-    }
-
-    await setNoteAndMeta(
-      toLocalRecord(resolved),
-      toLocalMeta(resolved, clock.now().toISOString()),
-    );
-  };
-
-  const reconcileRemote = async (
-    date: string,
-    localRecord: NoteRecord | null,
-    localMeta: NoteMetaRecord | null,
-  ): Promise<NoteEnvelope | null> => {
-    let remote: RemoteNote | null = null;
-    const remoteResult = await gateway.fetchNoteByDate(date);
-    if (!remoteResult.ok) {
-      return localRecord ? toNoteEnvelope(localRecord, localMeta) : null;
-    }
-    remote = remoteResult.value;
-
-    const meta: NoteMetaRecord | null =
-      localMeta ??
-      (localRecord
-        ? {
-            date,
-            revision: 1,
-            remoteId: null,
-            serverUpdatedAt: null,
-            lastSyncedAt: null,
-            pendingOp: "upsert",
-          }
-        : null);
-
-    if (meta?.pendingOp === "delete") {
-      if (remote) {
-        const deleted = await gateway.deleteNote({
-          id: meta.remoteId ?? undefined,
-          date,
-        });
-        unwrapOrThrow(deleted);
-      }
-      await deleteRemoteDate(date);
-      await deleteNoteAndMeta(date);
-      return null;
-    }
-
-    if (!remote || remote.deleted) {
-      if (!localRecord || !meta) {
-        return null;
-      }
-
-      if (meta.pendingOp === "upsert") {
-        const pushed = await pushLocal(localRecord, meta);
-        if (pushed) {
-          const now = clock.now().toISOString();
-          // Re-read current state to check if new edits happened during push
-          const currentState = await getNoteEnvelopeState(date);
-          const currentMeta = currentState.meta;
-          const currentRecord = currentState.record;
-          const newEditsOccurred =
-            currentMeta && currentMeta.revision > meta.revision;
-
-          if (newEditsOccurred && currentRecord) {
-            // New edits happened during push - only update server metadata,
-            // keep local content and pendingOp for next sync
-            await setNoteMeta({
-              ...currentMeta,
-              remoteId: pushed.id,
-              serverUpdatedAt: pushed.serverUpdatedAt,
-            });
-            return toNoteEnvelope(currentRecord, {
-              ...currentMeta,
-              remoteId: pushed.id,
-              serverUpdatedAt: pushed.serverUpdatedAt,
-            });
-          } else {
-            // No new edits - safe to overwrite with pushed content
-            const record = toLocalRecord(pushed);
-            const metaRecord = toLocalMeta(pushed, now);
-            await setNoteAndMeta(record, metaRecord);
-            return toNoteEnvelope(record, metaRecord);
-          }
-        }
-        return toNoteEnvelope(localRecord, meta);
-      }
-
-      await deleteRemoteDate(localRecord.date);
-      await deleteNoteAndMeta(localRecord.date);
-      return null;
-    }
-
-    if (!localRecord || !meta) {
-      const record = toLocalRecord(remote);
-      const metaRecord = toLocalMeta(remote, clock.now().toISOString());
-      await setNoteAndMeta(record, metaRecord);
-      return toNoteEnvelope(record, metaRecord);
-    }
-
-    // Skip conflict resolution if local is already synced with this remote version
-    if (meta.serverUpdatedAt === remote.serverUpdatedAt && !meta.pendingOp) {
-      return toNoteEnvelope(localRecord, meta);
-    }
-
-    if (meta.pendingOp === "upsert") {
-      const pushed = await pushLocal(localRecord, meta);
-      if (pushed?.deleted) {
-        await deleteNoteAndMeta(remote.date);
-        await deleteRemoteDate(remote.date);
-        return null;
-      }
-      if (pushed) {
-        const record = toLocalRecord(pushed);
-        const metaRecord = toLocalMeta(pushed, clock.now().toISOString());
-        await setNoteAndMeta(record, metaRecord);
-        return toNoteEnvelope(record, metaRecord);
-      }
-      return toNoteEnvelope(localRecord, meta);
-    }
-
-    // Resolve conflict between local and remote
-    const resolved = await resolveConflict({
-      gateway,
-      activeKeyId,
-      localRecord,
-      localMeta: meta,
-      remote,
-    });
-
-    if (resolved.deleted) {
-      await deleteNoteAndMeta(remote.date);
-      await deleteRemoteDate(remote.date);
-      return null;
-    }
-
-    const record = toLocalRecord(resolved);
-    const metaRecord = toLocalMeta(resolved, clock.now().toISOString());
-    await setNoteAndMeta(record, metaRecord);
-    return toNoteEnvelope(record, metaRecord);
-  };
-
   return {
     async getEnvelope(date: string): Promise<NoteEnvelope | null> {
       const snapshot = await getLocalSnapshot(date);
@@ -646,7 +424,66 @@ export function createUnifiedSyncedNoteEnvelopeRepository(
       }
       const snapshot = await getLocalSnapshot(date);
       try {
-        return await reconcileRemote(date, snapshot.record, snapshot.meta);
+        const remoteResult = await gateway.fetchNoteByDate(date);
+        if (!remoteResult.ok) {
+          return snapshot.envelope;
+        }
+        const remote = remoteResult.value;
+        const localRecord = snapshot.record;
+        const localMeta = snapshot.meta;
+        const now = clock.now().toISOString();
+
+        if (localMeta?.pendingOp === "delete") {
+          // Local delete pending — keep it, will push next sync
+          return snapshot.envelope;
+        }
+
+        if (!remote || remote.deleted) {
+          if (localMeta?.pendingOp === "upsert" && localRecord) {
+            // Local edit pending — keep local, update server metadata
+            const updatedMeta: NoteMetaRecord = {
+              ...localMeta,
+              remoteId: remote?.id ?? localMeta.remoteId,
+              serverRevision: remote?.revision ?? localMeta.serverRevision,
+              serverUpdatedAt:
+                remote?.serverUpdatedAt ?? localMeta.serverUpdatedAt,
+            };
+            await setNoteMeta(updatedMeta);
+            return toNoteEnvelope(localRecord, updatedMeta);
+          }
+          // No local edits — accept deletion
+          if (localRecord) {
+            await deleteNoteAndMeta(date);
+            await deleteRemoteDate(date);
+          }
+          return null;
+        }
+
+        if (!localRecord || !localMeta) {
+          // No local — accept remote
+          const record = toLocalRecord(remote);
+          const metaRecord = toLocalMeta(remote, now);
+          await setNoteAndMeta(record, metaRecord);
+          return toNoteEnvelope(record, metaRecord);
+        }
+
+        if (localMeta.pendingOp === "upsert") {
+          // Local edit pending — keep local content, update server metadata
+          const updatedMeta: NoteMetaRecord = {
+            ...localMeta,
+            remoteId: remote.id,
+            serverRevision: remote.revision,
+            serverUpdatedAt: remote.serverUpdatedAt,
+          };
+          await setNoteMeta(updatedMeta);
+          return toNoteEnvelope(localRecord, updatedMeta);
+        }
+
+        // No local pending — accept remote content
+        const record = toLocalRecord(remote);
+        const metaRecord = toLocalMeta(remote, now);
+        await setNoteAndMeta(record, metaRecord);
+        return toNoteEnvelope(record, metaRecord);
       } catch {
         return snapshot.envelope;
       }
@@ -674,6 +511,7 @@ export function createUnifiedSyncedNoteEnvelopeRepository(
       const meta: NoteMetaRecord = {
         date: payload.date,
         revision: (existingMeta?.revision ?? 0) + 1,
+        serverRevision: existingMeta?.serverRevision,
         remoteId: existingMeta?.remoteId ?? null,
         serverUpdatedAt: existingMeta?.serverUpdatedAt ?? null,
         lastSyncedAt: existingMeta?.lastSyncedAt ?? null,
@@ -686,6 +524,7 @@ export function createUnifiedSyncedNoteEnvelopeRepository(
       const meta: NoteMetaRecord = {
         date,
         revision: (existingMeta?.revision ?? 0) + 1,
+        serverRevision: existingMeta?.serverRevision,
         remoteId: existingMeta?.remoteId ?? null,
         serverUpdatedAt: existingMeta?.serverUpdatedAt ?? null,
         lastSyncedAt: existingMeta?.lastSyncedAt ?? null,

--- a/supabase/migrations/20260307_push_note_rpc.sql
+++ b/supabase/migrations/20260307_push_note_rpc.sql
@@ -1,0 +1,90 @@
+-- Server-enforced version gating for note sync
+-- Atomic check-and-increment replaces client-side conflict resolution
+
+-- push_note: insert (revision=1) or update (revision=expected+1), reject on mismatch
+create or replace function public.push_note(
+  p_id uuid,
+  p_user_id uuid,
+  p_date text,
+  p_key_id text,
+  p_ciphertext text,
+  p_nonce text,
+  p_revision integer,
+  p_updated_at timestamptz,
+  p_deleted boolean
+)
+returns public.notes
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  result public.notes;
+begin
+  if p_user_id != (select auth.uid()) then
+    raise exception 'AUTH_DENIED' using errcode = 'P0001';
+  end if;
+
+  if p_id is null then
+    -- Insert path: new note, revision starts at 1
+    insert into public.notes (user_id, date, key_id, ciphertext, nonce, revision, updated_at, deleted)
+    values (p_user_id, p_date, p_key_id, p_ciphertext, p_nonce, 1, p_updated_at, coalesce(p_deleted, false))
+    returning * into result;
+
+    return result;
+  end if;
+
+  -- Update path: atomically check expected revision and increment
+  update public.notes
+  set key_id = p_key_id,
+      ciphertext = p_ciphertext,
+      nonce = p_nonce,
+      revision = p_revision + 1,
+      updated_at = p_updated_at,
+      deleted = coalesce(p_deleted, false)
+  where id = p_id
+    and user_id = p_user_id
+    and revision = p_revision
+  returning * into result;
+
+  if not found then
+    raise exception 'VERSION_CONFLICT' using errcode = 'P0002';
+  end if;
+
+  return result;
+end;
+$$;
+
+-- delete_note: soft-delete with version check
+create or replace function public.delete_note(
+  p_id uuid,
+  p_user_id uuid,
+  p_revision integer
+)
+returns public.notes
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  result public.notes;
+begin
+  if p_user_id != (select auth.uid()) then
+    raise exception 'AUTH_DENIED' using errcode = 'P0001';
+  end if;
+
+  update public.notes
+  set deleted = true,
+      revision = p_revision + 1
+  where id = p_id
+    and user_id = p_user_id
+    and revision = p_revision
+  returning * into result;
+
+  if not found then
+    raise exception 'VERSION_CONFLICT' using errcode = 'P0002';
+  end if;
+
+  return result;
+end;
+$$;


### PR DESCRIPTION
## Summary
- Add `push_note` and `delete_note` SQL functions that atomically check expected revision and increment (or reject with `VERSION_CONFLICT`)
- Replace client-side conflict resolution (~200 lines: `resolveConflict`, `localWinsRemote`, `pushLocal`, `reconcileRemote`) with server-enforced version gating
- Gateway now uses `supabase.rpc()` instead of raw `.update()`/`.insert()`, mapping `P0002`/`23505` errors to `Conflict`
- Add `serverRevision` field to `NoteMetaRecord` to track server state independently from local edit counter
- Simplify `refreshEnvelope` from ~130 lines to ~30 lines (fetch + accept-or-keep, no push)

## Test plan
- [x] `npm run typecheck` — no type errors
- [x] `npm test` — all 563 tests pass
- [ ] Manual: create note → verify `revision = 1` in DB
- [ ] Manual: edit note → verify `revision = 2`
- [ ] Manual: simulate conflict (set revision higher in DB) → verify client pulls, retries, succeeds
- [ ] Manual: delete note → verify `deleted = true`, revision incremented
- [ ] Manual: offline edit → go online → verify sync completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)