### PR TITLE
fix: harden Zustand stores against race conditions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,8 @@ const _loadNote = async (date: string, repository: NoteRepository) => {
 
 After every `await`, re-read state via `get()` — never close over stale values.
 
+Stores also use a `_disposed` flag (checked after each `await`) to prevent post-dispose state updates from in-flight async operations.
+
 ### DI
 
 - Domain defines interfaces (Clock, Connectivity, KeyringProvider, SyncStateStore)
@@ -199,6 +201,7 @@ prompt: "Run `npm run typecheck` and report errors or confirm pass."
 - `docs/architecture-critique.md` — improvement proposals
 - `docs/data-flow.md` — local/cloud sync
 - `docs/key-derivation.md` — KEK/DEK, unlock flow
+- ~~`docs/effect-refactoring.md`~~ — deleted, superseded by Zustand migration
 
 ## Known Issues & Tech Debt
 
@@ -210,7 +213,7 @@ prompt: "Run `npm run typecheck` and report errors or confirm pass."
 ### Fixed by Zustand Migration (March 2026)
 
 The hook orchestration layer was rewritten from XState-based hooks to Zustand stores.
-Old files (`useLocalNoteContent.ts`, `useNoteRemoteSync.ts`, `useSyncMachine.ts`) kept for test backward compat only — dead code in production.
+Old XState hook files (`useLocalNoteContent.ts`, `useNoteRemoteSync.ts`, `useSyncMachine.ts`, `useNoteRepositoryMachine.ts`) and their tests have been deleted.
 
 Bugs fixed:
 - Save queue capturing stale repo/date → store reads `get()` at execution time
@@ -232,7 +235,6 @@ Bugs fixed:
 - Mixed DI: some singletons, some param-passed
 - `unifiedSyncedNoteRepository.ts` (668 lines) → split
 - No React Error Boundaries → runtime crash kills app
-- Delete old XState hook files once their tests are migrated to test Zustand stores
 
 
 ## grepai - Semantic Code Search

--- a/docs/architecture-critique.md
+++ b/docs/architecture-critique.md
@@ -44,12 +44,12 @@ const cacheKey = `${vaultKeyId}-${keyringToken}-${activeKeyId}-${supabaseSignatu
 
 This relies on object identity and string concatenation. No TTL, no explicit invalidation, no cleanup. If identity tracking fails silently, stale repos persist.
 
-### 4. 400+ Line God Hooks (Partially Resolved)
+### 4. 400+ Line God Hooks (Mostly Resolved)
 
-**March 2026 update**: `useSync.ts` and `useNoteRepository.ts` are now thin wrappers (~100 lines each) over Zustand stores. Logic lives in `src/stores/`.
+**March 2026 update**: `useSync.ts`, `useNoteRepository.ts`, `useNoteContent.ts`, `useNoteDates.ts` are now thin wrappers (~50-100 lines each) over Zustand stores. Logic lives in `src/stores/`. Old XState hook files have been deleted.
 
 Remaining:
-- `useActiveVault.ts` (486 lines) — still a god hook
+- `useActiveVault.ts` (~190 lines) — reduced but could be further split
 
 ### 5. Missing Error Boundaries
 
@@ -137,12 +137,12 @@ const repository = useMemo(() => {
 
 ### 4. Split God Hooks into Focused Units (Partially Done)
 
-**March 2026**: `useSync.ts`, `useNoteContent.ts`, `useNoteDates.ts`, `useNoteRepository.ts` are now thin wrappers. Logic in `src/stores/`.
+**March 2026**: `useSync.ts`, `useNoteContent.ts`, `useNoteDates.ts`, `useNoteRepository.ts` are now thin wrappers. Logic in `src/stores/`. Old XState hook files have been deleted.
 
-**Remaining**: `useActiveVault.ts` (486 lines) still a god hook. Could split into vault machine + unlock flows + keyring management.
+**Remaining**: `useActiveVault.ts` (~190 lines) — significantly reduced from 486 lines but could still be split into vault machine + unlock flows + keyring management.
 
 **Files to change**: `src/hooks/useActiveVault.ts` → multiple files
-**Effort**: Medium
+**Effort**: Low-Medium
 
 ### 5. Add Error Boundary + Recovery
 
@@ -177,35 +177,9 @@ Wrap at multiple levels:
 **Files to change**: Create `src/components/ErrorBoundary.tsx`, wrap in `App.tsx`
 **Effort**: Low
 
-### 6. Standardize Async Operations with AbortController
+### 6. ~~Standardize Async Operations with AbortController~~ → Done (March 2026)
 
-```typescript
-// src/utils/asyncHelpers.ts
-export function createCancellableOperation<T>(
-  operation: (signal: AbortSignal) => Promise<T>,
-  timeoutMs: number = 30000
-): { promise: Promise<T>, cancel: () => void } {
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
-
-  const promise = operation(controller.signal).finally(() => {
-    clearTimeout(timeoutId)
-  })
-
-  return { promise, cancel: () => controller.abort() }
-}
-
-// Usage in sync:
-const { promise, cancel } = createCancellableOperation(
-  (signal) => syncService.sync(signal),
-  60000
-)
-```
-
-Apply to all async loaders in `useActiveVault.ts` and sync operations.
-
-**Files to change**: Create `src/utils/asyncHelpers.ts`, update `useSync.ts`, `useActiveVault.ts`
-**Effort**: Medium
+`src/utils/asyncHelpers.ts` implements `createCancellableOperation` with AbortController and timeout support. Used by `syncStore.ts` for sync operations. Zustand stores also use generation counters and `_disposed` flags for async cancellation.
 
 ### 7. Add Integration Test Harness
 
@@ -245,8 +219,8 @@ Focus on:
 |-------------|--------|--------|----------|--------|
 | Error Boundary | High (stability) | Low | **P0** | Open |
 | Explicit cache invalidation | High (correctness) | Low-Med | **P1** | Open |
-| Standardize async patterns | Medium (reliability) | Medium | **P1** | **Done** (Zustand stores) |
-| Split god hooks | Medium (maintainability) | Medium | **P2** | **Partial** (vault remaining) |
+| Standardize async patterns | Medium (reliability) | Medium | **P1** | **Done** (asyncHelpers + Zustand stores) |
+| Split god hooks | Medium (maintainability) | Low-Med | **P2** | **Mostly done** (vault ~190 lines remaining) |
 | Unify state management | Medium (consistency) | Medium | **P2** | **Done** (Zustand) |
 | Flatten hook dependencies | High (testability) | High | **P2** | Open |
 | Integration tests | High (confidence) | High | **P3** | Open |
@@ -255,11 +229,12 @@ Focus on:
 
 ## Summary
 
-The architecture is fundamentally sound—local-first, E2EE, clean domain boundaries. The main issues are:
+The architecture is fundamentally sound—local-first, E2EE, clean domain boundaries. The remaining issues are:
 
-1. **Organic complexity** in state management (fix: standardize on XState)
+1. ~~**Organic complexity** in state management~~ → **Done**: Zustand stores standardized hook orchestration
 2. **Tight coupling** via deep hook chains (fix: context-injected services)
 3. **Implicit invalidation** in caching (fix: explicit version signals)
 4. **No error recovery** (fix: error boundaries)
+5. ~~**Inconsistent async patterns**~~ → **Done**: `asyncHelpers.ts` + generation counters + disposed flags
 
 Start with the error boundary (P0), then tackle caching correctness (P1). The larger refactors (P2-P3) can be done incrementally as the codebase evolves.

--- a/src/stores/noteContentStore.ts
+++ b/src/stores/noteContentStore.ts
@@ -124,8 +124,7 @@ export const noteContentStore = createStore<NoteContentState>()((set, get) => {
   };
 
   const _doSave = async (): Promise<void> => {
-    const { date, content, habits, repository, loadedWithContent, afterSave } =
-      get();
+    const { date, content, habits, repository, loadedWithContent } = get();
     if (!date || !repository) return;
 
     const isEmpty = isNoteEmpty(content, habits);
@@ -144,13 +143,21 @@ export const noteContentStore = createStore<NoteContentState>()((set, get) => {
     const current = get();
 
     if (result.ok) {
-      // If the user edited while save was in flight, stay dirty
-      if (current.date === date && current.content === content) {
+      // Only clear dirty state if content hasn't changed AND no new save is pending
+      if (
+        current.date === date &&
+        current.content === content &&
+        current._saveTimer === null
+      ) {
         set({ hasEdits: false, isSaving: false });
-      } else {
+      } else if (current._saveTimer === null) {
+        // Content changed but no new save scheduled
         set({ isSaving: false });
       }
-      afterSave?.({ date, content, isEmpty });
+      // else: new save timer pending — leave isSaving true
+
+      // Re-read afterSave after await to avoid calling a stale/disposed callback
+      current.afterSave?.({ date, content, isEmpty });
     } else {
       console.error("Failed to save note:", result.error);
       set({ isSaving: false });
@@ -254,6 +261,8 @@ export const noteContentStore = createStore<NoteContentState>()((set, get) => {
     afterSave: null,
 
     init: (date, repository, afterSave) => {
+      // Remove previous listener to avoid duplicates on re-init
+      document.removeEventListener("visibilitychange", _handleVisibilityChange);
       document.addEventListener("visibilitychange", _handleVisibilityChange);
       set({ repository, afterSave: afterSave ?? null });
       void _loadNote(date, repository);

--- a/src/stores/noteDatesStore.ts
+++ b/src/stores/noteDatesStore.ts
@@ -49,6 +49,7 @@ export interface NoteDatesState {
   isRefreshing: boolean;
   _refreshTimer: number | null;
   _refreshGeneration: number;
+  _disposed: boolean;
 
   // Actions
   init: (repository: NoteRepository, year: number) => void;
@@ -77,7 +78,7 @@ export const noteDatesStore = createStore<NoteDatesState>()((set, get) => {
     const { repository, year } = get();
     const online = connectivity.getOnline();
 
-    if (!repository) {
+    if (!repository || get()._disposed) {
       set({ noteDates: new Set(), isRefreshing: false });
       return;
     }
@@ -90,7 +91,7 @@ export const noteDatesStore = createStore<NoteDatesState>()((set, get) => {
       const localResult = supportsYearDates(repository)
         ? await repository.getAllLocalDatesForYear(year)
         : await repository.getAllLocalDates();
-      if (gen !== _refreshGeneration) return; // superseded
+      if (gen !== _refreshGeneration || get()._disposed) return; // superseded or disposed
       if (localResult.ok) {
         hasLocalSnapshot = true;
         set({ noteDates: new Set(localResult.value) });
@@ -102,7 +103,7 @@ export const noteDatesStore = createStore<NoteDatesState>()((set, get) => {
     // Refresh from remote if online
     if (online && supportsDateRefresh(repository)) {
       await repository.refreshDates(year);
-      if (gen !== _refreshGeneration) return; // superseded
+      if (gen !== _refreshGeneration || get()._disposed) return; // superseded or disposed
     }
 
     // Load full dates (local + remote merged)
@@ -110,7 +111,7 @@ export const noteDatesStore = createStore<NoteDatesState>()((set, get) => {
       ? await repository.getAllDatesForYear(year)
       : await repository.getAllDates();
 
-    if (gen !== _refreshGeneration) return; // superseded
+    if (gen !== _refreshGeneration || get()._disposed) return; // superseded or disposed
 
     if (datesResult.ok) {
       set({ noteDates: new Set(datesResult.value) });
@@ -130,9 +131,10 @@ export const noteDatesStore = createStore<NoteDatesState>()((set, get) => {
     isRefreshing: false,
     _refreshTimer: null,
     _refreshGeneration: 0,
+    _disposed: true,
 
     init: (repository, year) => {
-      set({ repository, year });
+      set({ repository, year, _disposed: false });
       void _doRefresh();
     },
 
@@ -144,6 +146,7 @@ export const noteDatesStore = createStore<NoteDatesState>()((set, get) => {
         noteDates: new Set(),
         isRefreshing: false,
         _refreshTimer: null,
+        _disposed: true,
       });
     },
 

--- a/src/stores/syncStore.ts
+++ b/src/stores/syncStore.ts
@@ -107,9 +107,17 @@ export const syncStore = createStore<SyncStoreState>()(subscribeWithSelector((se
     supabase: SupabaseClient,
     userId: string,
   ) => {
-    // Clean up previous
+    // Clean up previous channel and pending timers
     const prev = get()._realtimeChannel;
     if (prev) void prev.unsubscribe();
+    if (_realtimeDebounceTimer) {
+      window.clearTimeout(_realtimeDebounceTimer);
+      _realtimeDebounceTimer = null;
+    }
+    if (_realtimeRetryTimer) {
+      window.clearTimeout(_realtimeRetryTimer);
+      _realtimeRetryTimer = null;
+    }
 
     const channel = supabase
       .channel(`notes:${userId}`)


### PR DESCRIPTION
## Summary

- Fix five race condition / resource leak issues identified in PR #9 review
- Update AGENTS.md and architecture-critique.md to reflect current codebase state

## Store fixes

| Store | Issue | Fix |
|-------|-------|-----|
| `noteContentStore` | Duplicate `visibilitychange` listeners on re-init | `removeEventListener` before `addEventListener` in `init()` |
| `noteContentStore` | `hasEdits`/`isSaving` cleared while new save timer pending | Check `_saveTimer === null` before clearing dirty flags |
| `noteContentStore` | `afterSave` callback fires post-dispose via stale closure | Re-read `afterSave` from `get()` after await |
| `noteDatesStore` | No disposed guard on in-flight async ops | Add `_disposed` flag, check after every `await` |
| `syncStore` | Realtime debounce/retry timers orphaned on re-subscribe | Clear timers at start of `_subscribeRealtime()` |

## Doc updates

- AGENTS.md: Old XState files documented as deleted (not "kept for compat"), removed stale refactoring item, added `_disposed` pattern docs
- architecture-critique.md: Corrected `useActiveVault` line count (486→190), marked async proposal done, updated priority matrix and summary

## Test plan

- [x] `yarn test` — 44 suites, 561 tests pass
- [x] `yarn typecheck` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)