### PR TITLE
feat: show moon phase emoji before date in note header

### DIFF
--- a/src/__tests__/indicators.test.tsx
+++ b/src/__tests__/indicators.test.tsx
@@ -112,6 +112,7 @@ describe("SyncIndicator component", () => {
 
 describe("NoteEditorView status text", () => {
   const defaultProps = {
+    date: "16-01-2026",
     formattedDate: "January 16, 2026",
     isEditable: true,
     showReadonlyBadge: false,

--- a/src/__tests__/moonPhase.test.ts
+++ b/src/__tests__/moonPhase.test.ts
@@ -1,0 +1,40 @@
+import { getMoonPhaseEmoji } from "../utils/moonPhase";
+
+describe("getMoonPhaseEmoji", () => {
+  it("returns new moon emoji for a known new moon date", () => {
+    // January 6, 2000 was the reference new moon
+    expect(getMoonPhaseEmoji(new Date(2000, 0, 6))).toBe("🌑");
+  });
+
+  it("returns full moon emoji for ~14.76 days after new moon", () => {
+    // January 21, 2000 was a full moon
+    expect(getMoonPhaseEmoji(new Date(2000, 0, 21))).toBe("🌕");
+  });
+
+  it("returns first quarter for ~7.38 days after new moon", () => {
+    // January 14, 2000 — first quarter
+    expect(getMoonPhaseEmoji(new Date(2000, 0, 14))).toBe("🌓");
+  });
+
+  it("returns last quarter for ~22.15 days after new moon", () => {
+    // January 28, 2000 — last quarter
+    expect(getMoonPhaseEmoji(new Date(2000, 0, 28))).toBe("🌗");
+  });
+
+  it("returns a valid moon emoji for any date", () => {
+    const validEmojis = ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘"];
+    const dates = [
+      new Date(2024, 5, 15),
+      new Date(1999, 11, 31),
+      new Date(2030, 6, 4),
+    ];
+    for (const date of dates) {
+      expect(validEmojis).toContain(getMoonPhaseEmoji(date));
+    }
+  });
+
+  it("handles dates before the reference new moon", () => {
+    const validEmojis = ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘"];
+    expect(validEmojis).toContain(getMoonPhaseEmoji(new Date(1990, 0, 1)));
+  });
+});

--- a/src/__tests__/noteErrorDisplay.test.tsx
+++ b/src/__tests__/noteErrorDisplay.test.tsx
@@ -5,6 +5,7 @@ describe("NoteEditorHeader error display", () => {
   it("shows error text with error styling", () => {
     const { container } = render(
       <NoteEditorHeader
+        date="10-01-2026"
         formattedDate="January 10, 2026"
         showReadonlyBadge={false}
         statusText="Unable to decrypt note"
@@ -21,6 +22,7 @@ describe("NoteEditorHeader error display", () => {
   it("does not apply error class for normal saving status", () => {
     const { container } = render(
       <NoteEditorHeader
+        date="10-01-2026"
         formattedDate="January 10, 2026"
         showReadonlyBadge={false}
         statusText="Saving..."
@@ -37,6 +39,7 @@ describe("NoteEditorHeader error display", () => {
   it("hides status text when there is no status", () => {
     const { container } = render(
       <NoteEditorHeader
+        date="10-01-2026"
         formattedDate="January 10, 2026"
         showReadonlyBadge={false}
         statusText={null}

--- a/src/components/NoteEditor/NoteEditor.tsx
+++ b/src/components/NoteEditor/NoteEditor.tsx
@@ -190,6 +190,7 @@ export function NoteEditor({
   return (
     <>
       <NoteEditorView
+        date={date}
         formattedDate={formattedDate}
         isEditable={isEditable}
         showReadonlyBadge={!canEdit}

--- a/src/components/NoteEditor/NoteEditorHeader.tsx
+++ b/src/components/NoteEditor/NoteEditorHeader.tsx
@@ -1,6 +1,9 @@
+import { parseDate } from "../../utils/date";
+import { getMoonPhaseEmoji } from "../../utils/moonPhase";
 import styles from "./NoteEditor.module.css";
 
 interface NoteEditorHeaderProps {
+  date: string;
   formattedDate: string;
   showReadonlyBadge: boolean;
   statusText: string | null;
@@ -9,15 +12,22 @@ interface NoteEditorHeaderProps {
 }
 
 export function NoteEditorHeader({
+  date,
   formattedDate,
   showReadonlyBadge,
   statusText,
   isStatusError = false,
 }: NoteEditorHeaderProps) {
+  const parsed = parseDate(date);
+  const moonEmoji = parsed ? getMoonPhaseEmoji(parsed) : "";
+
   return (
     <div className={styles.header}>
       <div className={styles.headerTitle}>
-        <span className={styles.date}>{formattedDate}</span>
+        <span className={styles.date}>
+          {moonEmoji && <>{moonEmoji} </>}
+          {formattedDate}
+        </span>
         {showReadonlyBadge && (
           <span className={styles.readonlyBadge}>Read only</span>
         )}

--- a/src/components/NoteEditor/NoteEditorView.tsx
+++ b/src/components/NoteEditor/NoteEditorView.tsx
@@ -16,6 +16,7 @@ import type { DropIndicatorPosition } from "./useDropIndicator";
 import styles from "./NoteEditor.module.css";
 
 interface NoteEditorViewProps {
+  date: string;
   formattedDate: string;
   isEditable: boolean;
   showReadonlyBadge: boolean;
@@ -37,6 +38,7 @@ interface NoteEditorViewProps {
 }
 
 export function NoteEditorView({
+  date,
   formattedDate,
   isEditable,
   showReadonlyBadge,
@@ -93,6 +95,7 @@ export function NoteEditorView({
         />
       )}
       <NoteEditorHeader
+        date={date}
         formattedDate={formattedDate}
         showReadonlyBadge={showReadonlyBadge}
         statusText={statusText}

--- a/src/utils/moonPhase.ts
+++ b/src/utils/moonPhase.ts
@@ -1,0 +1,28 @@
+/** Synodic month length in days */
+const SYNODIC_MONTH = 29.53059;
+
+/** Known new moon: January 6, 2000 18:14 UTC */
+const REFERENCE_NEW_MOON = Date.UTC(2000, 0, 6, 18, 14);
+
+const MOON_PHASES = [
+  "\uD83C\uDF11", // 🌑 New Moon
+  "\uD83C\uDF12", // 🌒 Waxing Crescent
+  "\uD83C\uDF13", // 🌓 First Quarter
+  "\uD83C\uDF14", // 🌔 Waxing Gibbous
+  "\uD83C\uDF15", // 🌕 Full Moon
+  "\uD83C\uDF16", // 🌖 Waning Gibbous
+  "\uD83C\uDF17", // 🌗 Last Quarter
+  "\uD83C\uDF18", // 🌘 Waning Crescent
+] as const;
+
+/**
+ * Get the moon phase emoji for a given date.
+ * Uses a known new-moon reference and the synodic period to compute the phase.
+ */
+export function getMoonPhaseEmoji(date: Date): string {
+  const daysSinceRef =
+    (date.getTime() - REFERENCE_NEW_MOON) / (1000 * 60 * 60 * 24);
+  const phase = ((daysSinceRef % SYNODIC_MONTH) + SYNODIC_MONTH) % SYNODIC_MONTH;
+  const index = Math.round((phase / SYNODIC_MONTH) * 8) % 8;
+  return MOON_PHASES[index];
+}


### PR DESCRIPTION
Add moon phase calculation based on synodic cycle (~29.53 days) from a known new-moon reference. Displays one of 8 phase emojis (🌑🌒🌓🌔🌕🌖🌗🌘) before the formatted date in the note editor header.

https://claude.ai/code/session_01A49vADipGFgRZVKs7LXMtp