### PR TITLE
feat: dynamic journaling prompts and contextual empty note messages

### DIFF
--- a/src/__tests__/placeholderText.test.ts
+++ b/src/__tests__/placeholderText.test.ts
@@ -1,0 +1,260 @@
+import {
+  stringHash,
+  getTimePeriod,
+  getSeason,
+  getJournalingPrompt,
+  getPastEmptyMessage,
+  getFutureEmptyMessage,
+  getPlaceholderText,
+} from "../utils/placeholderText";
+import {
+  JOURNALING_PROMPTS,
+  PAST_EMPTY_MESSAGES,
+  FUTURE_EMPTY_MESSAGES,
+} from "../utils/placeholderPrompts";
+
+describe("stringHash", () => {
+  it("returns a non-negative integer", () => {
+    expect(stringHash("hello")).toBeGreaterThanOrEqual(0);
+    expect(Number.isInteger(stringHash("hello"))).toBe(true);
+  });
+
+  it("is deterministic", () => {
+    expect(stringHash("test")).toBe(stringHash("test"));
+    expect(stringHash("04-03-2026")).toBe(stringHash("04-03-2026"));
+  });
+
+  it("produces different values for different inputs", () => {
+    const a = stringHash("01-01-2024");
+    const b = stringHash("02-01-2024");
+    const c = stringHash("01-01-2025");
+    // Not all the same (extremely unlikely with djb2)
+    expect(new Set([a, b, c]).size).toBeGreaterThan(1);
+  });
+});
+
+describe("getTimePeriod", () => {
+  it.each([
+    [5, "morning"],
+    [6, "morning"],
+    [11, "morning"],
+    [12, "afternoon"],
+    [14, "afternoon"],
+    [16, "afternoon"],
+    [17, "evening"],
+    [19, "evening"],
+    [20, "evening"],
+    [21, "night"],
+    [23, "night"],
+    [0, "night"],
+    [4, "night"],
+  ] as const)("hour %i → %s", (hour, expected) => {
+    expect(getTimePeriod(hour)).toBe(expected);
+  });
+});
+
+describe("getSeason", () => {
+  it.each([
+    [0, "winter"], // January
+    [1, "winter"], // February
+    [2, "spring"], // March
+    [3, "spring"], // April
+    [4, "spring"], // May
+    [5, "summer"], // June
+    [6, "summer"], // July
+    [7, "summer"], // August
+    [8, "fall"], // September
+    [9, "fall"], // October
+    [10, "fall"], // November
+    [11, "winter"], // December
+  ] as const)("month %i → %s", (month, expected) => {
+    expect(getSeason(month)).toBe(expected);
+  });
+});
+
+describe("getJournalingPrompt", () => {
+  it("returns a non-empty string", () => {
+    const result = getJournalingPrompt(
+      "04-03-2026",
+      new Date(2026, 2, 4, 9, 0),
+    );
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("is deterministic for same date and time period", () => {
+    const now1 = new Date(2026, 2, 4, 9, 0); // 9 AM
+    const now2 = new Date(2026, 2, 4, 10, 30); // 10:30 AM (same period)
+    expect(getJournalingPrompt("04-03-2026", now1)).toBe(
+      getJournalingPrompt("04-03-2026", now2),
+    );
+  });
+
+  it("changes when time period changes", () => {
+    const morning = new Date(2026, 2, 4, 9, 0);
+    const evening = new Date(2026, 2, 4, 19, 0);
+    const morningPrompt = getJournalingPrompt("04-03-2026", morning);
+    const eveningPrompt = getJournalingPrompt("04-03-2026", evening);
+    // Different periods should pick from different pools — overwhelming
+    // likelihood of different result, but theoretically could collide.
+    // We test the mechanism, not randomness.
+    expect(typeof morningPrompt).toBe("string");
+    expect(typeof eveningPrompt).toBe("string");
+  });
+
+  it("never returns a past-tense reflective prompt in the morning", () => {
+    const morningPrompts = JOURNALING_PROMPTS.filter((p) =>
+      p.periods.includes("morning"),
+    );
+    const pastTensePatterns = [
+      /^How was your day/,
+      /stayed with you/,
+      /did you avoid/,
+      /did you learn about yourself/,
+      /would you do differently/,
+    ];
+    for (const prompt of morningPrompts) {
+      for (const pattern of pastTensePatterns) {
+        expect(prompt.text).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it("does not return weekendOnly prompts on weekdays", () => {
+    // Wednesday March 4, 2026
+    const wednesday = new Date(2026, 2, 4, 14, 0);
+    const weekendPrompts = JOURNALING_PROMPTS.filter((p) => p.weekendOnly).map(
+      (p) => p.text,
+    );
+
+    // Run many salt values to check none return a weekend prompt
+    for (let salt = 0; salt < 50; salt++) {
+      const result = getJournalingPrompt("04-03-2026", wednesday, salt);
+      expect(weekendPrompts).not.toContain(result);
+    }
+  });
+
+  it("does not return weekdayOnly prompts on weekends", () => {
+    // Saturday March 7, 2026
+    const saturday = new Date(2026, 2, 7, 9, 0);
+    const weekdayPrompts = JOURNALING_PROMPTS.filter((p) => p.weekdayOnly).map(
+      (p) => p.text,
+    );
+
+    for (let salt = 0; salt < 50; salt++) {
+      const result = getJournalingPrompt("07-03-2026", saturday, salt);
+      expect(weekdayPrompts).not.toContain(result);
+    }
+  });
+
+  it("returns a different prompt when salt changes", () => {
+    const now = new Date(2026, 2, 4, 14, 0);
+    const results = new Set<string>();
+    for (let salt = 0; salt < 20; salt++) {
+      results.add(getJournalingPrompt("04-03-2026", now, salt));
+    }
+    // With 20 different salts, we should get more than 1 unique prompt
+    expect(results.size).toBeGreaterThan(1);
+  });
+});
+
+describe("getPastEmptyMessage", () => {
+  it("returns a string from PAST_EMPTY_MESSAGES", () => {
+    const result = getPastEmptyMessage("15-06-2020");
+    expect(PAST_EMPTY_MESSAGES).toContain(result);
+  });
+
+  it("is deterministic per date", () => {
+    expect(getPastEmptyMessage("01-01-2020")).toBe(
+      getPastEmptyMessage("01-01-2020"),
+    );
+  });
+
+  it("different dates can produce different messages", () => {
+    const results = new Set<string>();
+    for (let i = 1; i <= 20; i++) {
+      results.add(getPastEmptyMessage(`${String(i).padStart(2, "0")}-01-2020`));
+    }
+    expect(results.size).toBeGreaterThan(1);
+  });
+});
+
+describe("getFutureEmptyMessage", () => {
+  it("returns a string from FUTURE_EMPTY_MESSAGES", () => {
+    const result = getFutureEmptyMessage("15-06-2030");
+    expect(FUTURE_EMPTY_MESSAGES).toContain(result);
+  });
+
+  it("is deterministic per date", () => {
+    expect(getFutureEmptyMessage("01-01-2030")).toBe(
+      getFutureEmptyMessage("01-01-2030"),
+    );
+  });
+
+  it("different dates can produce different messages", () => {
+    const results = new Set<string>();
+    for (let i = 1; i <= 20; i++) {
+      results.add(
+        getFutureEmptyMessage(`${String(i).padStart(2, "0")}-06-2030`),
+      );
+    }
+    expect(results.size).toBeGreaterThan(1);
+  });
+});
+
+describe("getPlaceholderText", () => {
+  const base = {
+    isContentReady: true,
+    isDecrypting: false,
+    isOfflineStub: false,
+    isEditable: false,
+    date: "15-01-2020",
+  };
+
+  it('returns "Loading..." when content is not ready', () => {
+    expect(
+      getPlaceholderText({ ...base, isContentReady: false }),
+    ).toBe("Loading...");
+  });
+
+  it('returns "Loading..." when decrypting', () => {
+    expect(
+      getPlaceholderText({ ...base, isDecrypting: true }),
+    ).toBe("Loading...");
+  });
+
+  it("returns offline message when offline stub", () => {
+    expect(
+      getPlaceholderText({ ...base, isOfflineStub: true }),
+    ).toBe(
+      "This note can't be loaded while offline. Go online to view it.",
+    );
+  });
+
+  it("returns a journaling prompt when editable (today)", () => {
+    const result = getPlaceholderText({
+      ...base,
+      isEditable: true,
+      date: "04-03-2026",
+      now: new Date(2026, 2, 4, 14, 0),
+    });
+    // Should be one of the prompts, not the old static text
+    expect(result).not.toBe("Write your note for today...");
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("returns a past message for a past non-editable date", () => {
+    const result = getPlaceholderText({
+      ...base,
+      date: "01-01-2020", // well in the past
+    });
+    expect(PAST_EMPTY_MESSAGES).toContain(result);
+  });
+
+  it("returns a future message for a future non-editable date", () => {
+    const result = getPlaceholderText({
+      ...base,
+      date: "01-01-2099", // well in the future
+    });
+    expect(FUTURE_EMPTY_MESSAGES).toContain(result);
+  });
+});

--- a/src/__tests__/userFlows.test.tsx
+++ b/src/__tests__/userFlows.test.tsx
@@ -336,9 +336,10 @@ describe("Local Mode User Flow", () => {
     const editor = getEditor();
     expect(editor.getAttribute("contenteditable")).toBe("true");
     expect(editor.getAttribute("aria-readonly")).toBe("false");
-    expect(editor.getAttribute("data-placeholder")).toBe(
-      "Write your note for today...",
-    );
+    // Placeholder should be a journaling prompt (not the old static text)
+    const placeholder = editor.getAttribute("data-placeholder") ?? "";
+    expect(placeholder.length).toBeGreaterThan(0);
+    expect(placeholder).not.toBe("Write your note for today...");
 
     // Verify date in header
     const today = new Date();

--- a/src/components/Calendar/MonthViewLayout.tsx
+++ b/src/components/Calendar/MonthViewLayout.tsx
@@ -3,6 +3,7 @@ import { ErrorBoundary } from "../ErrorBoundary";
 import { NavigationArrow } from "../NavigationArrow";
 import { NoteEditor } from "../NoteEditor";
 import { MonthGrid } from "./MonthGrid";
+import { PromptCard } from "./PromptCard";
 import styles from "./MonthViewLayout.module.css";
 
 const BLUR_INACTIVITY_MS = 2 * 60 * 1000; // 2 minutes
@@ -134,6 +135,8 @@ export function MonthViewLayout({
             ariaLabel="Next note"
           />
         </div>
+
+        <PromptCard />
       </div>
 
       <div className={styles.editorPane}>

--- a/src/components/Calendar/PromptCard.module.css
+++ b/src/components/Calendar/PromptCard.module.css
@@ -1,0 +1,18 @@
+.promptCard {
+  all: unset;
+  display: block;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xl);
+  font-style: italic;
+  text-align: center;
+  padding: var(--spacing-lg) var(--spacing-xl);
+  cursor: pointer;
+  flex-shrink: 0;
+  line-height: var(--line-height-relaxed);
+  user-select: none;
+  transition: opacity var(--transition-fast);
+}
+
+.promptCard:hover {
+  opacity: 0.6;
+}

--- a/src/components/Calendar/PromptCard.tsx
+++ b/src/components/Calendar/PromptCard.tsx
@@ -1,0 +1,26 @@
+import { useCallback, useMemo, useState } from "react";
+import { getTodayString } from "../../utils/date";
+import { getJournalingPrompt } from "../../utils/placeholderText";
+import styles from "./PromptCard.module.css";
+
+export function PromptCard() {
+  const [salt, setSalt] = useState(0);
+  const dateStr = getTodayString();
+  const now = useMemo(() => new Date(), []);
+  const prompt = getJournalingPrompt(dateStr, now, salt);
+
+  const handleClick = useCallback(() => {
+    setSalt((s) => s + 1);
+  }, []);
+
+  return (
+    <button
+      type="button"
+      className={styles.promptCard}
+      onClick={handleClick}
+      title="Click for another prompt"
+    >
+      {prompt}
+    </button>
+  );
+}

--- a/src/components/NoteEditor/NoteEditor.tsx
+++ b/src/components/NoteEditor/NoteEditor.tsx
@@ -2,6 +2,7 @@ import { useCallback } from "react";
 import type { DragEvent } from "react";
 import { formatDateDisplay } from "../../utils/date";
 import { canEditNote } from "../../utils/noteRules";
+import { getPlaceholderText } from "../../utils/placeholderText";
 import { NoteEditorView } from "./NoteEditorView";
 import { useContentEditableEditor } from "./useContentEditableEditor";
 import { useSavingIndicator } from "./useSavingIndicator";
@@ -62,14 +63,13 @@ export function NoteEditor({
       : shouldShowSaving
         ? "Saving..."
         : null;
-  const placeholderText =
-    !isContentReady || isDecrypting
-      ? "Loading..."
-      : isOfflineStub
-        ? "This note can't be loaded while offline. Go online to view it."
-        : isEditable
-          ? "Write your note for today..."
-          : "No note for this day";
+  const placeholderText = getPlaceholderText({
+    isContentReady,
+    isDecrypting,
+    isOfflineStub,
+    isEditable,
+    date,
+  });
 
   const { isDraggingImage, endImageDrag } = useImageDragState();
   const weather = useWeatherContext();

--- a/src/utils/placeholderPrompts.ts
+++ b/src/utils/placeholderPrompts.ts
@@ -1,0 +1,861 @@
+export type TimePeriod = "morning" | "afternoon" | "evening" | "night";
+
+export type Season = "spring" | "summer" | "fall" | "winter";
+
+export interface JournalingPrompt {
+  text: string;
+  periods: TimePeriod[];
+  seasons?: Season[];
+  weekendOnly?: boolean;
+  weekdayOnly?: boolean;
+}
+
+export const JOURNALING_PROMPTS: JournalingPrompt[] = [
+  // ── Universal / any time ──────────────────────────────────────────
+  {
+    text: "What's on your mind?",
+    periods: ["morning", "afternoon", "evening", "night"],
+  },
+  {
+    text: "What are you grateful for right now?",
+    periods: ["morning", "afternoon", "evening", "night"],
+  },
+  {
+    text: "How are you feeling right now?",
+    periods: ["morning", "afternoon", "evening", "night"],
+  },
+  {
+    text: "What did you appreciate about your environment?",
+    periods: ["morning", "afternoon", "evening", "night"],
+  },
+
+  // ── Morning ───────────────────────────────────────────────────────
+  {
+    text: "What would make today meaningful?",
+    periods: ["morning", "afternoon"],
+  },
+  {
+    text: "What are you looking forward to today?",
+    periods: ["morning"],
+  },
+  {
+    text: "What's your intention for today?",
+    periods: ["morning"],
+  },
+  {
+    text: "What energy are you bringing into today?",
+    periods: ["morning"],
+  },
+  {
+    text: "What's one thing you'd like to accomplish today?",
+    periods: ["morning", "afternoon"],
+  },
+  {
+    text: "How did you sleep?",
+    periods: ["morning"],
+  },
+  {
+    text: "What's the first thing on your mind this morning?",
+    periods: ["morning"],
+  },
+  {
+    text: "What deserves your attention today?",
+    periods: ["morning"],
+  },
+  {
+    text: "What is the single most important thing today?",
+    periods: ["morning"],
+  },
+  {
+    text: "What mood do you wake up with?",
+    periods: ["morning"],
+  },
+  {
+    text: "What does your body feel like right now?",
+    periods: ["morning"],
+  },
+  {
+    text: "What thought is already present this morning?",
+    periods: ["morning"],
+  },
+  {
+    text: "What would make today successful?",
+    periods: ["morning"],
+  },
+  {
+    text: "What would make today peaceful?",
+    periods: ["morning"],
+  },
+  {
+    text: "What might challenge you today?",
+    periods: ["morning"],
+  },
+  {
+    text: "What habit do you want to practice today?",
+    periods: ["morning"],
+  },
+  {
+    text: "What intention will guide your actions today?",
+    periods: ["morning"],
+  },
+  {
+    text: "What deserves your attention early rather than later?",
+    periods: ["morning"],
+  },
+  {
+    text: "What would you like to notice more today?",
+    periods: ["morning"],
+  },
+
+  // ── Afternoon / midday ────────────────────────────────────────────
+  {
+    text: "How's your day going so far?",
+    periods: ["afternoon"],
+  },
+  {
+    text: "What's been the best part of today?",
+    periods: ["afternoon", "evening"],
+  },
+  {
+    text: "What surprised you today?",
+    periods: ["afternoon", "evening"],
+  },
+  {
+    text: "What did you learn today?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What moment today felt most alive?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What small decision shaped your day?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "How has your energy changed since morning?",
+    periods: ["afternoon"],
+  },
+  {
+    text: "What has gone better than expected so far?",
+    periods: ["afternoon"],
+  },
+  {
+    text: "What has been frustrating so far?",
+    periods: ["afternoon"],
+  },
+  {
+    text: "What task is currently most important?",
+    periods: ["afternoon"],
+  },
+  {
+    text: "What distraction has appeared today?",
+    periods: ["afternoon"],
+  },
+  {
+    text: "What conversation affected your mood?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What detail of the day stands out right now?",
+    periods: ["afternoon"],
+  },
+  {
+    text: "What would help you reset for the afternoon?",
+    periods: ["afternoon"],
+  },
+  {
+    text: "What have you done well so far today?",
+    periods: ["afternoon"],
+  },
+  {
+    text: "What are you postponing right now?",
+    periods: ["afternoon"],
+  },
+  {
+    text: "What environment are you in, and how does it affect you?",
+    periods: ["afternoon"],
+  },
+
+  // ── Evening ───────────────────────────────────────────────────────
+  {
+    text: "How was your day?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What made you smile today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What's something you did well today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What are you letting go of today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "How do you want to feel tomorrow?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What challenged you today?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What are you taking with you into tomorrow?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What did you avoid today, and why?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What drained your energy?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What gave you energy?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What thought repeated the most today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What did you learn about yourself today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What tension did you carry in your body?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "When did you feel calm today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What expectation did reality contradict today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What detail would most people overlook today?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What did you postpone that matters?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What felt meaningful today?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What felt pointless today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What conversation stayed with you?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What did you notice about your mood patterns?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What desire influenced your actions today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What fear influenced your actions today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What was the most beautiful thing you saw?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What idea appeared briefly but was interesting?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What irritated you more than it should have?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What habit showed up today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What would you do differently if you repeated today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What felt effortless today?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What felt unnecessarily difficult?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What did you notice about time passing today?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What emotion was strongest today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What did you ignore that deserves attention?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What unfinished thought remains from today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What did you create today?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What environment affected your mood most?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What risk did you take today?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What pattern from the past reappeared today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What would you title today if it were a book chapter?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What did today teach you about patience?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What deserves attention tomorrow?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What problem occupied your mind the most?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What question about life came up today?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What's something you noticed today?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What's one thing you want to remember about today?",
+    periods: ["afternoon", "evening", "night"],
+  },
+  {
+    text: "What moment defined the day?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What did you accomplish today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What did you struggle with today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What did you notice about your reactions?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What interaction mattered most today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What would you repeat from today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What emotion stayed with you longest today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What did you neglect today?",
+    periods: ["evening", "night"],
+  },
+  {
+    text: "What deserves appreciation from today?",
+    periods: ["evening", "night"],
+  },
+
+  // ── Late night / reflection ───────────────────────────────────────
+  {
+    text: "What's on your mind before bed?",
+    periods: ["night"],
+  },
+  {
+    text: "What thought remains unresolved tonight?",
+    periods: ["night"],
+  },
+  {
+    text: "What are you still thinking about before sleep?",
+    periods: ["night"],
+  },
+  {
+    text: "What tension is still in your body?",
+    periods: ["night"],
+  },
+  {
+    text: "What can you let go of from today?",
+    periods: ["night"],
+  },
+  {
+    text: "What did today reveal about your priorities?",
+    periods: ["night"],
+  },
+  {
+    text: "What did today reveal about your habits?",
+    periods: ["night"],
+  },
+  {
+    text: "What would you tell your morning self now?",
+    periods: ["night"],
+  },
+  {
+    text: "What is one insight from today worth remembering?",
+    periods: ["night"],
+  },
+  {
+    text: "What small win did you overlook?",
+    periods: ["night"],
+  },
+  {
+    text: "What deserves gratitude tonight?",
+    periods: ["night"],
+  },
+  {
+    text: "What are you curious about tomorrow?",
+    periods: ["night"],
+  },
+  {
+    text: "What intention will you carry into the next day?",
+    periods: ["night"],
+  },
+
+  // ── Weekend ───────────────────────────────────────────────────────
+  {
+    text: "What's your plan for a restful day?",
+    periods: ["morning", "afternoon"],
+    weekendOnly: true,
+  },
+  {
+    text: "How are you spending your time off?",
+    periods: ["morning", "afternoon", "evening"],
+    weekendOnly: true,
+  },
+  {
+    text: "What's something fun you did today?",
+    periods: ["afternoon", "evening"],
+    weekendOnly: true,
+  },
+  {
+    text: "What made this weekend feel different from weekdays?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What did you do purely because you wanted to?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What slowed you down this weekend?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What did you notice when you had more time?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What part of the weekend felt most restorative?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What did you do that your weekday self rarely does?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What place did you visit or explore?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What conversation stood out this weekend?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What did you learn about how you rest?",
+    periods: ["evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What did you create or build this weekend?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What distracted you from resting?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What hobby or curiosity did you follow?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What did you observe about your pace of life?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What would make next weekend better?",
+    periods: ["evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What did you do with your hands this weekend?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What moment felt simple and complete?",
+    periods: ["afternoon", "evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What unfinished thought will carry into the week?",
+    periods: ["evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What intention do you want to bring into Monday?",
+    periods: ["evening", "night"],
+    weekendOnly: true,
+  },
+  {
+    text: "What memory from this weekend will stay with you?",
+    periods: ["evening", "night"],
+    weekendOnly: true,
+  },
+
+  // ── Weekday ───────────────────────────────────────────────────────
+  {
+    text: "What's on your plate at work today?",
+    periods: ["morning"],
+    weekdayOnly: true,
+  },
+  {
+    text: "What's the most important thing to get done today?",
+    periods: ["morning", "afternoon"],
+    weekdayOnly: true,
+  },
+
+  // ── Spring ───────────────────────────────────────────────────────
+  {
+    text: "What in your life currently feels like a beginning?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["spring"],
+  },
+  {
+    text: "What idea is starting to take shape?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["spring"],
+  },
+  {
+    text: "What habit would you like to plant this season?",
+    periods: ["morning", "afternoon"],
+    seasons: ["spring"],
+  },
+  {
+    text: "What in your environment is changing right now?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["spring"],
+  },
+  {
+    text: "What feels fresh or renewed in your life?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["spring"],
+  },
+  {
+    text: "What have you outgrown recently?",
+    periods: ["afternoon", "evening", "night"],
+    seasons: ["spring"],
+  },
+  {
+    text: "What small sign of growth did you notice today?",
+    periods: ["afternoon", "evening", "night"],
+    seasons: ["spring"],
+  },
+  {
+    text: "What possibility excites you this spring?",
+    periods: ["morning", "afternoon"],
+    seasons: ["spring"],
+  },
+  {
+    text: "What would you like to nurture more carefully?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["spring"],
+  },
+  {
+    text: "What energy returns to you with longer days?",
+    periods: ["morning", "afternoon"],
+    seasons: ["spring"],
+  },
+  {
+    text: "What project deserves a first step?",
+    periods: ["morning", "afternoon"],
+    seasons: ["spring"],
+  },
+  {
+    text: "What does starting again mean to you now?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["spring"],
+  },
+
+  // ── Summer ──────────────────────────────────────────────────────
+  {
+    text: "What activity makes you feel most alive in summer?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["summer"],
+  },
+  {
+    text: "What part of the day feels most expansive?",
+    periods: ["afternoon", "evening"],
+    seasons: ["summer"],
+  },
+  {
+    text: "What place do you want to spend more time in?",
+    periods: ["morning", "afternoon"],
+    seasons: ["summer"],
+  },
+  {
+    text: "What sensory detail defines today?",
+    periods: ["afternoon", "evening", "night"],
+    seasons: ["summer"],
+  },
+  {
+    text: "What experience do you want to fully savor?",
+    periods: ["morning", "afternoon"],
+    seasons: ["summer"],
+  },
+  {
+    text: "What social moment stands out today?",
+    periods: ["afternoon", "evening", "night"],
+    seasons: ["summer"],
+  },
+  {
+    text: "What feels abundant right now?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["summer"],
+  },
+  {
+    text: "What does a perfect summer day look like to you?",
+    periods: ["morning", "afternoon"],
+    seasons: ["summer"],
+  },
+  {
+    text: "What rhythm does your life fall into during summer?",
+    periods: ["afternoon", "evening", "night"],
+    seasons: ["summer"],
+  },
+  {
+    text: "What adventure would you like to take this season?",
+    periods: ["morning", "afternoon"],
+    seasons: ["summer"],
+  },
+  {
+    text: "What moment today felt carefree?",
+    periods: ["afternoon", "evening", "night"],
+    seasons: ["summer"],
+  },
+  {
+    text: "What do long evenings invite you to reflect on?",
+    periods: ["evening", "night"],
+    seasons: ["summer"],
+  },
+
+  // ── Fall ────────────────────────────────────────────────────────
+  {
+    text: "What in your life is ready to be completed?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["fall"],
+  },
+  {
+    text: "What are you harvesting from earlier efforts?",
+    periods: ["afternoon", "evening", "night"],
+    seasons: ["fall"],
+  },
+  {
+    text: "What habit or commitment deserves evaluation?",
+    periods: ["afternoon", "evening", "night"],
+    seasons: ["fall"],
+  },
+  {
+    text: "What have you learned this year so far?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["fall"],
+  },
+  {
+    text: "What feels mature or settled in your life?",
+    periods: ["afternoon", "evening", "night"],
+    seasons: ["fall"],
+  },
+  {
+    text: "What are you ready to let go of?",
+    periods: ["evening", "night"],
+    seasons: ["fall"],
+  },
+  {
+    text: "What memory surfaced while noticing the season change?",
+    periods: ["afternoon", "evening", "night"],
+    seasons: ["fall"],
+  },
+  {
+    text: "What routine becomes more important as days shorten?",
+    periods: ["morning", "afternoon"],
+    seasons: ["fall"],
+  },
+  {
+    text: "What work requires focus now?",
+    periods: ["morning", "afternoon"],
+    seasons: ["fall"],
+  },
+  {
+    text: "What quiet moment defined today?",
+    periods: ["evening", "night"],
+    seasons: ["fall"],
+  },
+  {
+    text: "What do you want to preserve from this year?",
+    periods: ["evening", "night"],
+    seasons: ["fall"],
+  },
+  {
+    text: "What transition are you currently experiencing?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["fall"],
+  },
+
+  // ── Winter ──────────────────────────────────────────────────────
+  {
+    text: "What does rest mean for you right now?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["winter"],
+  },
+  {
+    text: "What feels quiet or slowed down in your life?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["winter"],
+  },
+  {
+    text: "What thought keeps returning during still moments?",
+    periods: ["evening", "night"],
+    seasons: ["winter"],
+  },
+  {
+    text: "What do you reflect on more in winter?",
+    periods: ["afternoon", "evening", "night"],
+    seasons: ["winter"],
+  },
+  {
+    text: "What comfort do you appreciate most today?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["winter"],
+  },
+  {
+    text: "What inner work calls for attention?",
+    periods: ["afternoon", "evening", "night"],
+    seasons: ["winter"],
+  },
+  {
+    text: "What memory surfaced during a quiet evening?",
+    periods: ["evening", "night"],
+    seasons: ["winter"],
+  },
+  {
+    text: "What does darkness or cold invite you to consider?",
+    periods: ["evening", "night"],
+    seasons: ["winter"],
+  },
+  {
+    text: "What idea deserves deeper contemplation this season?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["winter"],
+  },
+  {
+    text: "What part of yourself needs patience right now?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["winter"],
+  },
+  {
+    text: "What silence revealed something today?",
+    periods: ["evening", "night"],
+    seasons: ["winter"],
+  },
+  {
+    text: "What intention will you carry through the winter?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["winter"],
+  },
+
+  // ── Seasonal transitions ───────────────────────────────────────
+  {
+    text: "What change in the air or light did you notice today?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["spring", "summer", "fall", "winter"],
+  },
+  {
+    text: "What season of your life does this moment resemble?",
+    periods: ["morning", "afternoon", "evening", "night"],
+    seasons: ["spring", "summer", "fall", "winter"],
+  },
+];
+
+export const PAST_EMPTY_MESSAGES: string[] = [
+  "Nothing here \u2014 it was probably a busy day!",
+  "This day slipped by without a note",
+  "Some days are best lived, not written about",
+  "A quiet day in the journal",
+  "This page stayed blank \u2014 and that's okay",
+  "No words captured, but the day still happened",
+  "Sometimes silence is the best entry",
+  "An unwritten day, full of its own stories",
+  "The pen rested on this one",
+  "Not every day needs to be documented",
+];
+
+export const FUTURE_EMPTY_MESSAGES: string[] = [
+  "This day hasn't happened yet!",
+  "The page is waiting for this day to arrive",
+  "A blank canvas for a day yet to come",
+  "This story hasn't been written yet",
+  "Still in the future \u2014 check back later!",
+  "Nothing to see here yet \u2014 this day is still ahead",
+  "The ink hasn't dried on this day yet",
+  "A day waiting to unfold",
+  "Tomorrow's pages are always empty",
+  "This day is still on its way",
+];

--- a/src/utils/placeholderText.ts
+++ b/src/utils/placeholderText.ts
@@ -1,0 +1,107 @@
+import { isFuture } from "./date";
+import {
+  type TimePeriod,
+  type Season,
+  JOURNALING_PROMPTS,
+  PAST_EMPTY_MESSAGES,
+  FUTURE_EMPTY_MESSAGES,
+} from "./placeholderPrompts";
+
+/**
+ * Deterministic hash of a string to a non-negative integer (djb2).
+ */
+export function stringHash(str: string): number {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) + hash + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+/** Get time period from hour (0-23). */
+export function getTimePeriod(hour: number): TimePeriod {
+  if (hour >= 5 && hour < 12) return "morning";
+  if (hour >= 12 && hour < 17) return "afternoon";
+  if (hour >= 17 && hour < 21) return "evening";
+  return "night";
+}
+
+/** Get season from month index (0-11). Northern hemisphere. */
+export function getSeason(month: number): Season {
+  if (month >= 2 && month <= 4) return "spring";
+  if (month >= 5 && month <= 7) return "summer";
+  if (month >= 8 && month <= 10) return "fall";
+  return "winter";
+}
+
+function isWeekend(dayOfWeek: number): boolean {
+  return dayOfWeek === 0 || dayOfWeek === 6;
+}
+
+/**
+ * Select a journaling prompt for today.
+ * Deterministic within a (date, timePeriod) pair.
+ * Accepts optional `salt` to force a different pick (for shuffle).
+ */
+export function getJournalingPrompt(
+  dateStr: string,
+  now: Date = new Date(),
+  salt = 0,
+): string {
+  const hour = now.getHours();
+  const period = getTimePeriod(hour);
+  const season = getSeason(now.getMonth());
+  const weekend = isWeekend(now.getDay());
+
+  const candidates = JOURNALING_PROMPTS.filter((p) => {
+    if (!p.periods.includes(period)) return false;
+    if (p.seasons && !p.seasons.includes(season)) return false;
+    if (p.weekendOnly && !weekend) return false;
+    if (p.weekdayOnly && weekend) return false;
+    return true;
+  });
+
+  // Fallback: if no candidates after all filters, use period-only
+  const pool =
+    candidates.length > 0
+      ? candidates
+      : JOURNALING_PROMPTS.filter((p) => p.periods.includes(period));
+
+  const hash = stringHash(dateStr + period + (salt > 0 ? String(salt) : ""));
+  return pool[hash % pool.length].text;
+}
+
+/** Get an empty-note message for a past date. Deterministic per date. */
+export function getPastEmptyMessage(dateStr: string): string {
+  const hash = stringHash(dateStr);
+  return PAST_EMPTY_MESSAGES[hash % PAST_EMPTY_MESSAGES.length];
+}
+
+/** Get an empty-note message for a future date. Deterministic per date. */
+export function getFutureEmptyMessage(dateStr: string): string {
+  const hash = stringHash(dateStr);
+  return FUTURE_EMPTY_MESSAGES[hash % FUTURE_EMPTY_MESSAGES.length];
+}
+
+/**
+ * Get the appropriate placeholder text for a note.
+ * Replaces the inline ternary in NoteEditor.tsx.
+ */
+export function getPlaceholderText(options: {
+  isContentReady: boolean;
+  isDecrypting: boolean;
+  isOfflineStub: boolean;
+  isEditable: boolean;
+  date: string;
+  now?: Date;
+}): string {
+  const { isContentReady, isDecrypting, isOfflineStub, isEditable, date, now } =
+    options;
+
+  if (!isContentReady || isDecrypting) return "Loading...";
+  if (isOfflineStub)
+    return "This note can't be loaded while offline. Go online to view it.";
+  if (isEditable) return getJournalingPrompt(date, now);
+  if (isFuture(date)) return getFutureEmptyMessage(date);
+  return getPastEmptyMessage(date);
+}


### PR DESCRIPTION
## Summary
- Replace static placeholder text ("Write your note for today...") with ~160 time-aware, season-aware journaling prompts that shift with morning/afternoon/evening/night and seasons
- Add 10 cheerful rotating messages each for empty past dates and future dates
- Add a clickable prompt card below the month grid that shuffles to a new prompt on click
- All selection is deterministic per (date, time period) via djb2 hash — no randomness, same date+time always shows the same prompt

## Test plan
- [x] 47 new tests in `placeholderText.test.ts` covering hash, time periods, seasons, prompt filtering, salt shuffle, and orchestrator
- [x] All 621 tests pass (`npx jest`)
- [x] TypeScript typecheck passes (`npx tsc --noEmit`)
- [ ] Manual: verify today's empty note shows a contextual prompt
- [ ] Manual: verify empty past date shows a cheerful message
- [ ] Manual: verify month view prompt card appears and shuffles on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)