### PR TITLE
Use beforeinput for +section transform (mobile fix)

### DIFF
--- a/src/__tests__/noteEditorSection.test.tsx
+++ b/src/__tests__/noteEditorSection.test.tsx
@@ -11,6 +11,20 @@ function setCaretAtEnd(element: HTMLElement) {
   selection.addRange(range);
 }
 
+/**
+ * Dispatch a native beforeinput event with insertParagraph.
+ * Mobile keyboards don't fire keydown for Enter, but beforeinput
+ * fires reliably — this mirrors the production code path.
+ */
+function fireInsertParagraph(element: HTMLElement) {
+  const event = new Event("beforeinput", {
+    cancelable: true,
+    bubbles: true,
+  });
+  (event as Event & { inputType: string }).inputType = "insertParagraph";
+  element.dispatchEvent(event);
+}
+
 function EditorHarness({
   content,
   onChange,
@@ -52,7 +66,7 @@ describe("Structured section transform", () => {
     const div = editor.querySelector("div") as HTMLDivElement;
     setCaretAtEnd(div);
 
-    fireEvent.keyDown(editor, { key: "Enter" });
+    fireInsertParagraph(editor);
 
     await waitFor(() => {
       const header = editor.querySelector("[data-section-type]");
@@ -75,7 +89,7 @@ describe("Structured section transform", () => {
     const div = editor.querySelector("div") as HTMLDivElement;
     setCaretAtEnd(div);
 
-    fireEvent.keyDown(editor, { key: "Enter" });
+    fireInsertParagraph(editor);
 
     expect(editor.querySelector("[data-section-type]")).toBeNull();
   });
@@ -93,7 +107,7 @@ describe("Structured section transform", () => {
     const div = editor.querySelector("div") as HTMLDivElement;
     setCaretAtEnd(div);
 
-    fireEvent.keyDown(editor, { key: "Enter" });
+    fireInsertParagraph(editor);
 
     await waitFor(() => {
       const header = editor.querySelector("[data-section-type]");
@@ -135,7 +149,7 @@ describe("Structured section transform", () => {
     expect(trumpetDiv).not.toBeNull();
     setCaretAtEnd(trumpetDiv!);
 
-    fireEvent.keyDown(editor, { key: "Enter" });
+    fireInsertParagraph(editor);
 
     await waitFor(() => {
       const header = editor.querySelector("[data-section-type]");
@@ -154,7 +168,7 @@ describe("Structured section transform", () => {
     editor.textContent = "+trumpet";
     setCaretAtEnd(editor);
 
-    fireEvent.keyDown(editor, { key: "Enter" });
+    fireInsertParagraph(editor);
 
     await waitFor(() => {
       const header = editor.querySelector("[data-section-type]");
@@ -191,8 +205,8 @@ describe("Structured section transform", () => {
     // Simulate typing — this triggers handleInput which may insert timestamp HR
     fireEvent.input(editor);
 
-    // Now press Enter to trigger section transform
-    fireEvent.keyDown(editor, { key: "Enter" });
+    // Now fire beforeinput to trigger section transform
+    fireInsertParagraph(editor);
 
     await waitFor(() => {
       const header = editor.querySelector("[data-section-type]");
@@ -248,7 +262,7 @@ describe("Structured section transform", () => {
     sel.removeAllRanges();
     sel.addRange(range);
 
-    fireEvent.keyDown(editor, { key: "Enter" });
+    fireInsertParagraph(editor);
 
     await waitFor(() => {
       const header = editor.querySelector("[data-section-type]");

--- a/src/components/NoteEditor/useContentEditableEditor.ts
+++ b/src/components/NoteEditor/useContentEditableEditor.ts
@@ -723,94 +723,110 @@ export function useContentEditableEditor({
 
   }, []);
 
-  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
-    if (!isEditableRef.current) return;
+  // Section transform via beforeinput — mobile keyboards don't
+  // fire keydown for Enter, but beforeinput fires reliably.
+  useEffect(() => {
+    const el = editorRef.current;
+    if (!el) return;
 
-    // Section transform: +typename on Enter or Shift+Enter
-    if (event.key === "Enter") {
-      const el = editorRef.current;
-      if (el) {
-        const selection = window.getSelection();
-        if (selection && selection.rangeCount > 0) {
-          const range = selection.getRangeAt(0);
-          let container: Node | null = range.startContainer;
-          const textNode =
-            container.nodeType === Node.TEXT_NODE ? container : null;
-          if (container.nodeType === Node.TEXT_NODE) {
-            container = container.parentNode;
-          }
-          let block: HTMLElement | null = null;
-          let current: Node | null = container;
-          while (current && current !== el) {
+    const handleBeforeInput = (event: InputEvent) => {
+      if (!isEditableRef.current) return;
+      if (
+        event.inputType !== "insertParagraph" &&
+        event.inputType !== "insertLineBreak"
+      ) {
+        return;
+      }
+
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) return;
+
+      const range = selection.getRangeAt(0);
+      let container: Node | null = range.startContainer;
+      const textNode =
+        container.nodeType === Node.TEXT_NODE ? container : null;
+      if (container.nodeType === Node.TEXT_NODE) {
+        container = container.parentNode;
+      }
+
+      let block: HTMLElement | null = null;
+      let current: Node | null = container;
+      while (current && current !== el) {
+        if (
+          current instanceof HTMLElement &&
+          (current.tagName === "DIV" || current.tagName === "P")
+        ) {
+          block = current;
+          break;
+        }
+        current = current.parentNode;
+      }
+
+      // Bare text node directly inside editor — wrap in div first
+      if (!block && container === el) {
+        const targetNode = textNode ?? (() => {
+          for (const child of Array.from(el.childNodes)) {
             if (
-              current instanceof HTMLElement &&
-              (current.tagName === "DIV" || current.tagName === "P")
+              child.nodeType === Node.TEXT_NODE &&
+              (child.textContent ?? "").trim().match(SECTION_TYPE_RE)
             ) {
-              block = current;
-              break;
-            }
-            current = current.parentNode;
-          }
-          // If text is a bare text node directly inside the editor (no wrapping div),
-          // wrap it in a div so the section transform can proceed
-          if (!block && container === el) {
-            // Find the text node near the cursor
-            const targetNode = textNode ?? (() => {
-              for (const child of Array.from(el.childNodes)) {
-                if (
-                  child.nodeType === Node.TEXT_NODE &&
-                  (child.textContent ?? "").trim().match(SECTION_TYPE_RE)
-                ) {
-                  return child;
-                }
-              }
-              return null;
-            })();
-            if (targetNode && targetNode.parentNode === el) {
-              const text = (targetNode.textContent ?? "").trim();
-              if (text.match(SECTION_TYPE_RE)) {
-                const wrapper = document.createElement("div");
-                el.insertBefore(wrapper, targetNode);
-                wrapper.appendChild(targetNode);
-                block = wrapper;
-              }
+              return child;
             }
           }
-          if (block) {
-            const text = (block.textContent ?? "").trim();
-            const match = text.match(SECTION_TYPE_RE);
-            if (match) {
-              event.preventDefault();
-              const typeName = match[1];
-              block.setAttribute("data-section-type", typeName);
-              block.textContent = "+" + typeName;
-
-              const body = document.createElement("div");
-              body.appendChild(document.createElement("br"));
-              block.parentNode?.insertBefore(body, block.nextSibling);
-
-              applySectionColors(el);
-
-              const sel = window.getSelection();
-              if (sel) {
-                const r = document.createRange();
-                r.setStart(body, 0);
-                r.collapse(true);
-                sel.removeAllRanges();
-                sel.addRange(r);
-              }
-
-              const html = serializeEditorContent(el);
-              lastContentRef.current = html;
-              isLocalEditRef.current = true;
-              onChangeRef.current(html);
-              onUserInputRef.current?.();
-              return;
-            }
+          return null;
+        })();
+        if (targetNode && targetNode.parentNode === el) {
+          const text = (targetNode.textContent ?? "").trim();
+          if (text.match(SECTION_TYPE_RE)) {
+            const wrapper = document.createElement("div");
+            el.insertBefore(wrapper, targetNode);
+            wrapper.appendChild(targetNode);
+            block = wrapper;
           }
         }
       }
-    }
+
+      if (!block) return;
+
+      const text = (block.textContent ?? "").trim();
+      const match = text.match(SECTION_TYPE_RE);
+      if (!match) return;
+
+      event.preventDefault();
+      const typeName = match[1];
+      block.setAttribute("data-section-type", typeName);
+      block.textContent = "+" + typeName;
+
+      const body = document.createElement("div");
+      body.appendChild(document.createElement("br"));
+      block.parentNode?.insertBefore(body, block.nextSibling);
+
+      applySectionColors(el);
+
+      const sel = window.getSelection();
+      if (sel) {
+        const r = document.createRange();
+        r.setStart(body, 0);
+        r.collapse(true);
+        sel.removeAllRanges();
+        sel.addRange(r);
+      }
+
+      const html = serializeEditorContent(el);
+      lastContentRef.current = html;
+      isLocalEditRef.current = true;
+      onChangeRef.current(html);
+      onUserInputRef.current?.();
+    };
+
+    el.addEventListener("beforeinput", handleBeforeInput);
+    return () => {
+      el.removeEventListener("beforeinput", handleBeforeInput);
+    };
+  }, []);
+
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    if (!isEditableRef.current) return;
 
     // Normalize Shift+Enter to insertLineBreak for cross-browser consistency
     if (event.key === "Enter" && event.shiftKey) {


### PR DESCRIPTION
## Summary
- Moved +section transform from `keydown` (Enter) to native `beforeinput` (`insertParagraph`/`insertLineBreak`) event
- Mobile keyboards don't fire `keydown` for Enter reliably — `beforeinput` works on both desktop and mobile
- Updated all section tests to dispatch `beforeinput` events instead of `keyDown`

## Test plan
- [x] 608/608 tests pass, zero type errors
- [x] Dev server loads without errors
- [x] Section transform works via `beforeinput` in browser preview
- [ ] Test on mobile device: type `+dream`, tap Enter → section created

🤖 Generated with [Claude Code](https://claude.com/claude-code)