### PR TITLE
Reduce duplicate network requests on page load

### DIFF
--- a/src/hooks/useNoteRepository.ts
+++ b/src/hooks/useNoteRepository.ts
@@ -209,13 +209,13 @@ export function useNoteRepository({
   // Cross-concern coordination via Zustand subscribe()
   // When sync completes or realtime changes arrive, refresh current note
   useEffect(() => {
-    // Sync completion → refresh current note
+    // Sync completion → re-read note from local (sync already updated IndexedDB)
     const unsubSync = syncStore.subscribe(
       (s) => s.syncCompletionCount,
       () => {
         const ns = noteContentStore.getState();
         if (ns.date && !ns.hasEdits && (ns.status === "ready" || ns.status === "error")) {
-          ns.forceRefresh();
+          void ns.reloadFromLocal();
         }
       },
     );

--- a/src/stores/noteContentStore.ts
+++ b/src/stores/noteContentStore.ts
@@ -49,6 +49,7 @@ export interface NoteContentState {
   flushSave: () => Promise<void>;
   applyRemoteUpdate: (content: string) => void;
   refreshFromRemote: () => Promise<void>;
+  reloadFromLocal: () => Promise<void>;
   forceRefresh: () => void;
   checkRemoteCache: () => Promise<void>;
   setAfterSave: (callback?: (snapshot: SaveSnapshot) => void) => void;
@@ -356,6 +357,24 @@ export const noteContentStore = createStore<NoteContentState>()((set, get) => {
         if (gen === _refreshGeneration) {
           set({ isRefreshing: false });
         }
+      }
+    },
+
+    reloadFromLocal: async () => {
+      const { date, repository, hasEdits } = get();
+      if (!date || !repository || hasEdits) return;
+      try {
+        const result = await repository.get(date);
+        const current = get();
+        if (current.date !== date || current.hasEdits) return;
+        if (result.ok) {
+          const content = result.value?.content ?? "";
+          if (content !== current.content) {
+            set({ content, hasEdits: false, error: null });
+          }
+        }
+      } catch {
+        // Local read failed — not critical, skip
       }
     },
 

--- a/src/stores/syncStore.ts
+++ b/src/stores/syncStore.ts
@@ -65,6 +65,8 @@ export const syncStore = createStore<SyncStoreState>()(subscribeWithSelector((se
   let _realtimeDebounceTimer: number | null = null;
   let _realtimeRetryTimer: number | null = null;
   let _isInitialRealtimeConnect = false;
+  let _initTimestamp = 0;
+  const INIT_GRACE_PERIOD_MS = 5000;
 
   const _refreshPendingOps = async () => {
     try {
@@ -204,6 +206,7 @@ export const syncStore = createStore<SyncStoreState>()(subscribeWithSelector((se
         get().dispose();
       }
 
+      _initTimestamp = Date.now();
       const online = connectivity.getOnline();
 
       // Create sync service reusing domain code
@@ -395,6 +398,8 @@ export const syncStore = createStore<SyncStoreState>()(subscribeWithSelector((se
     handleWindowFocus: () => {
       const state = get();
       if (state._disposed || !state._intentScheduler) return;
+      // Skip if still within the init grace period — init already triggered a sync
+      if (Date.now() - _initTimestamp < INIT_GRACE_PERIOD_MS) return;
       state._intentScheduler.requestSync({ immediate: true });
       void _refreshPendingOps();
     },


### PR DESCRIPTION
## Summary
- Add `reloadFromLocal` to noteContentStore — re-reads from IndexedDB without a network fetch. After sync completes, the local DB is already up to date, so a separate `refreshNote` HTTP call is unnecessary.
- Change post-sync subscriber to use `reloadFromLocal` instead of `forceRefresh`, eliminating redundant single-note fetches after each sync completion.
- Add 5s grace period after `syncStore.init()` to suppress `handleWindowFocus` sync requests. On page load, `focus` and `visibilitychange` events fire naturally and queue extra syncs before the initial sync even completes.

**Before:** ~4 `refreshNote` + ~3 sync pull requests on cloud-mode page load  
**After:** 1 `refreshNote` + 1 sync pull + 1 `fetchNoteDates`

## Test plan
- [ ] Verify cloud-mode page load shows minimal network requests (1 sync pull, 1 refreshNote, 1 fetchNoteDates)
- [ ] Verify note content updates after sync completes (reloadFromLocal picks up changes)
- [ ] Verify returning to tab after >5s still triggers a sync
- [ ] Verify realtime changes still update the displayed note

🤖 Generated with [Claude Code](https://claude.com/claude-code)