### PR TITLE
Fix slow note loading after fresh sign-in

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -167,9 +167,7 @@ function App() {
                     date={date}
                     noteDates={notes.noteDates}
                     hasNote={notes.hasNote}
-                    onDayClick={
-                      activeVault.isVaultUnlocked ? navigateToDate : () => {}
-                    }
+                    onDayClick={navigateToDate}
                     onYearChange={navigateToYear}
                     onMonthChange={handleDayViewMonthChange}
                     onReturnToYear={handleReturnToYear}
@@ -193,15 +191,9 @@ function App() {
                     weekStartVersion={weekStartVersion}
                     year={year}
                     hasNote={notes.hasNote}
-                    onDayClick={
-                      activeVault.isVaultUnlocked ? navigateToDate : undefined
-                    }
+                    onDayClick={navigateToDate}
                     onYearChange={navigateToYear}
-                    onMonthClick={
-                      activeVault.isVaultUnlocked
-                        ? handleCalendarMonthClick
-                        : undefined
-                    }
+                    onMonthClick={handleCalendarMonthClick}
                     syncStatus={canSync ? notes.syncStatus : undefined}
                     syncError={canSync ? notes.syncError : undefined}
                     pendingOps={canSync ? notes.pendingOps : undefined}

--- a/src/hooks/useNoteContent.ts
+++ b/src/hooks/useNoteContent.ts
@@ -282,7 +282,10 @@ export function useNoteContent(
 
   const isReady =
     status === "ready" || status === "error";
-  const isLoading = status === "loading";
+  // Treat "date set but no repository yet" as loading so the editor
+  // shows "Decrypting..." while the vault is still unlocking.
+  const isLoading =
+    status === "loading" || (date !== null && repository === null);
 
   // Determine offline stub
   const isOfflineStub =

--- a/src/hooks/useNoteRepository.ts
+++ b/src/hooks/useNoteRepository.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { User } from "@supabase/supabase-js";
 import { useNoteContent } from "./useNoteContent";
 import { useNoteDates } from "./useNoteDates";
@@ -88,6 +88,16 @@ export function useNoteRepository({
   const envelopePort = useMemo(() => createNoteEnvelopeAdapter(), []);
   const remoteDateIndex = useMemo(() => createRemoteDateIndexAdapter(), []);
 
+  // Ref keeps keyProvider.getKey() reading the latest keyring without
+  // recreating the repository (and restarting sync) on every keyring
+  // reference change.  The keyring Map changes multiple times after
+  // sign-in as the vault machine loads local keys and caches cloud
+  // keys — none of those changes should interrupt an in-flight sync.
+  const keyringRef = useRef(keyring);
+  useEffect(() => {
+    keyringRef.current = keyring;
+  }, [keyring]);
+
   const syncedFactories = useMemo<SyncedRepositoryFactories>(
     () => ({
       createSyncedNoteRepository: ({ userId, keyProvider, envelopePort, remoteDateIndex }) => {
@@ -118,9 +128,11 @@ export function useNoteRepository({
     void repositoryVersion;
     const keyProvider = {
       activeKeyId,
-      getKey: (keyId: string) => keyring.get(keyId) ?? null,
+      getKey: (keyId: string) => keyringRef.current.get(keyId) ?? null,
     };
 
+    // getKey reads the ref at I/O time (decrypt), never during render
+    // eslint-disable-next-line react-hooks/refs
     return createNoteRepository({
       mode,
       userId,
@@ -134,7 +146,6 @@ export function useNoteRepository({
     userId,
     vaultKey,
     activeKeyId,
-    keyring,
     syncedFactories,
     envelopePort,
     remoteDateIndex,
@@ -146,8 +157,9 @@ export function useNoteRepository({
     void repositoryVersion;
     const keyProvider = {
       activeKeyId,
-      getKey: (keyId: string) => keyring.get(keyId) ?? null,
+      getKey: (keyId: string) => keyringRef.current.get(keyId) ?? null,
     };
+    // eslint-disable-next-line react-hooks/refs
     return createImageRepository({
       mode,
       userId,
@@ -159,7 +171,6 @@ export function useNoteRepository({
     activeKeyId,
     mode,
     userId,
-    keyring,
     syncedFactories,
     repositoryVersion,
   ]);


### PR DESCRIPTION
## Summary

- **Stabilize repository across keyring changes**: After sign-in, the vault machine goes through multiple phases (loading local keyring, caching cloud keys), each producing a new `keyring` Map reference. Previously this recreated the repository each time, cancelling in-flight sync and resetting note content mid-load. Now `keyProvider.getKey()` reads the keyring from a ref, so only meaningful changes (`activeKeyId`, `vaultKey`) trigger recreation.

- **Always navigate on dot click**: Removed the `isVaultUnlocked` gate from `onDayClick`/`onMonthClick`. Clicking a date dot always navigates to the DayView. When the vault is still unlocking (repository not yet available), the editor shows "Decrypting..." instead of silently doing nothing.

## Test plan

- [x] All 611 tests pass
- [x] TypeScript type checker clean
- [x] ESLint clean
- [ ] Manual: sign in on fresh browser, verify dots load and first click on a date opens note with "Decrypting..." then content
- [ ] Manual: verify no "Syncing" flash on date navigation after initial sync completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)