### PR TITLE
Add markdown export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ dist-ssr
 .grepai/
 /.serena/
 .superpowers/
+docs/superpowers/

--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.89.0",
     "dompurify": "^3.3.1",
+    "fflate": "^0.8.2",
     "lucide-react": "^0.563.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "turndown": "^7.2.2",
     "zustand": "^5.0.11"
   },
   "devDependencies": {
@@ -45,6 +47,7 @@
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
+    "@types/turndown": "^5.0.6",
     "@vitejs/plugin-react": "^6.0.1",
     "cheerio": "^1.0.0",
     "dotenv": "^17.2.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { AppModals } from "./components/AppModals";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { UpdatePrompt } from "./components/UpdatePrompt";
 import { SettingsSidebar } from "./components/SettingsSidebar";
+import { exportNotesAsZip, downloadBlob } from "./services/exportNotes";
 import { AboutModal } from "./components/AppModals/AboutModal";
 import { PrivacyPolicyModal } from "./components/AppModals/PrivacyPolicyModal";
 import { AuthState } from "./hooks/useAuth";
@@ -114,6 +115,14 @@ function App() {
     setWeekStartVersion((value) => value + 1);
   }, []);
 
+  const handleExport = useCallback(async () => {
+    if (!notes.repository) return;
+    const blob = await exportNotesAsZip(notes.repository);
+    if (!blob) return;
+    const today = new Date().toISOString().slice(0, 10);
+    downloadBlob(blob, `ichinichi-export-${today}.zip`);
+  }, [notes.repository]);
+
   const signInHandler =
     appMode.mode !== AppMode.Cloud && auth.authState !== AuthState.SignedIn
       ? appMode.switchToCloud
@@ -219,6 +228,7 @@ function App() {
                   onOpenAbout={handleOpenAbout}
                   onOpenPrivacy={handleOpenPrivacy}
                   onWeekStartChange={handleWeekStartChange}
+                  onExport={notes.repository ? handleExport : undefined}
                 />
 
                 <AppModals />

--- a/src/__tests__/exportNotes.test.ts
+++ b/src/__tests__/exportNotes.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import {
+  dateToFilename,
+  createTurndown,
+  htmlToMarkdown,
+  exportNotesAsZip,
+} from "../services/exportNotes";
+import { ok, err } from "../domain/result";
+import type { NoteRepository } from "../storage/noteRepository";
+
+describe("dateToFilename", () => {
+  it("converts DD-MM-YYYY to YYYY-MM-DD", () => {
+    expect(dateToFilename("16-03-2026")).toBe("2026-03-16");
+    expect(dateToFilename("01-01-2020")).toBe("2020-01-01");
+    expect(dateToFilename("31-12-1999")).toBe("1999-12-31");
+  });
+});
+
+describe("htmlToMarkdown", () => {
+  const td = createTurndown();
+
+  it("converts basic text", () => {
+    expect(htmlToMarkdown("<p>Hello world</p>", td)).toBe("Hello world");
+  });
+
+  it("converts bold and italic", () => {
+    expect(htmlToMarkdown("<b>bold</b>", td)).toBe("**bold**");
+    expect(htmlToMarkdown("<i>italic</i>", td)).toBe("_italic_");
+  });
+
+  it("converts links", () => {
+    expect(
+      htmlToMarkdown(
+        '<a href="https://example.com">link</a>',
+        td,
+      ),
+    ).toBe("[link](https://example.com)");
+  });
+
+  it("converts timestamp HR to markdown HR with time comment", () => {
+    const html =
+      '<hr data-timestamp="2026-03-04T07:06:25.486Z" data-label="8:06 AM" contenteditable="false">';
+    const result = htmlToMarkdown(html, td);
+    expect(result).toContain("---");
+    expect(result).toContain("<!-- time: 8:06 AM -->");
+  });
+
+  it("converts timestamp HR without label to plain HR", () => {
+    const html = '<hr data-timestamp="2026-03-04T07:06:25.486Z">';
+    const result = htmlToMarkdown(html, td);
+    expect(result).toBe("---");
+  });
+
+  it("converts section label to h2", () => {
+    const html = '<div data-section-type="trumpet">+trumpet</div>';
+    const result = htmlToMarkdown(html, td);
+    expect(result).toBe("## +trumpet");
+  });
+
+  it("converts image placeholder", () => {
+    const html = '<img data-image-id="abc123">';
+    const result = htmlToMarkdown(html, td);
+    expect(result).toBe("<!-- image: abc123 -->");
+  });
+
+  it("handles mixed content", () => {
+    const html = [
+      '<hr data-timestamp="2026-03-04T07:06:25.486Z" data-label="8:06 AM" contenteditable="false">',
+      "<div>Some text here.</div>",
+      '<div data-section-type="dream">+dream</div>',
+      "<div>Dream content.</div>",
+    ].join("");
+    const result = htmlToMarkdown(html, td);
+    expect(result).toContain("---");
+    expect(result).toContain("<!-- time: 8:06 AM -->");
+    expect(result).toContain("Some text here.");
+    expect(result).toContain("## +dream");
+    expect(result).toContain("Dream content.");
+  });
+
+  it("converts headings", () => {
+    expect(htmlToMarkdown("<h1>Title</h1>", td)).toBe("# Title");
+    expect(htmlToMarkdown("<h2>Sub</h2>", td)).toBe("## Sub");
+  });
+
+  it("converts blockquote", () => {
+    expect(htmlToMarkdown("<blockquote>quote</blockquote>", td)).toBe(
+      "> quote",
+    );
+  });
+
+  it("converts code", () => {
+    expect(htmlToMarkdown("<code>const x = 1</code>", td)).toBe(
+      "`const x = 1`",
+    );
+  });
+});
+
+describe("exportNotesAsZip", () => {
+  function mockRepo(
+    dates: string[],
+    notes: Record<string, string>,
+  ): NoteRepository {
+    return {
+      getAllDates: vi.fn().mockResolvedValue(ok(dates)),
+      getAllDatesForYear: vi.fn().mockResolvedValue(ok([])),
+      get: vi.fn().mockImplementation((date: string) => {
+        const content = notes[date];
+        if (!content) return Promise.resolve(ok(null));
+        return Promise.resolve(
+          ok({
+            date,
+            content,
+            updatedAt: new Date().toISOString(),
+          }),
+        );
+      }),
+      save: vi.fn().mockResolvedValue(ok(undefined)),
+      delete: vi.fn().mockResolvedValue(ok(undefined)),
+    };
+  }
+
+  it("returns null for empty notes", async () => {
+    const repo = mockRepo([], {});
+    const result = await exportNotesAsZip(repo);
+    expect(result).toBeNull();
+  });
+
+  it("returns a zip blob for notes", async () => {
+    const repo = mockRepo(["16-03-2026"], {
+      "16-03-2026": "<p>Hello world</p>",
+    });
+    const result = await exportNotesAsZip(repo);
+    expect(result).toBeInstanceOf(Blob);
+    expect(result!.type).toBe("application/zip");
+    expect(result!.size).toBeGreaterThan(0);
+  });
+
+  it("throws on repository error", async () => {
+    const repo: NoteRepository = {
+      getAllDates: vi
+        .fn()
+        .mockResolvedValue(err({ type: "IO", message: "fail" })),
+      getAllDatesForYear: vi.fn().mockResolvedValue(ok([])),
+      get: vi.fn(),
+      save: vi.fn(),
+      delete: vi.fn(),
+    };
+    await expect(exportNotesAsZip(repo)).rejects.toThrow(
+      "Failed to fetch note dates",
+    );
+  });
+
+  it("skips notes with empty content", async () => {
+    const repo = mockRepo(["16-03-2026", "17-03-2026"], {
+      "16-03-2026": "<p></p>",
+      "17-03-2026": "<p>Real content</p>",
+    });
+    const result = await exportNotesAsZip(repo);
+    expect(result).toBeInstanceOf(Blob);
+  });
+});

--- a/src/components/SettingsSidebar/SettingsSidebar.tsx
+++ b/src/components/SettingsSidebar/SettingsSidebar.tsx
@@ -13,6 +13,7 @@ import {
   GitBranch,
   ChevronRight,
   ExternalLink,
+  Download,
   X,
 } from "lucide-react";
 import { useTheme } from "@/hooks/useTheme";
@@ -32,6 +33,7 @@ interface SettingsSidebarProps {
   onOpenAbout?: () => void;
   onOpenPrivacy?: () => void;
   onWeekStartChange?: () => void;
+  onExport?: () => Promise<void>;
 }
 
 type WeatherState = ReturnType<typeof useWeatherContext>["state"];
@@ -267,6 +269,54 @@ function WeatherSection({
   );
 }
 
+function DataSection({
+  onExport,
+}: {
+  onExport: () => Promise<void>;
+}) {
+  const [status, setStatus] = useState<
+    "idle" | "exporting" | "done" | "empty" | "error"
+  >("idle");
+
+  const handleExport = useCallback(async () => {
+    if (status === "exporting") return;
+    setStatus("exporting");
+    try {
+      await onExport();
+      setStatus("done");
+    } catch {
+      setStatus("error");
+    }
+    setTimeout(() => setStatus("idle"), 2000);
+  }, [onExport, status]);
+
+  const label =
+    status === "exporting"
+      ? "Exporting..."
+      : status === "done"
+        ? "Exported!"
+        : status === "empty"
+          ? "No notes to export"
+          : status === "error"
+            ? "Export failed"
+            : "Export as Markdown";
+
+  return (
+    <div className={styles.section}>
+      <p className={styles.sectionLabel}>Data</p>
+      <button
+        className={styles.actionButton}
+        type="button"
+        onClick={handleExport}
+        disabled={status === "exporting"}
+      >
+        <Download className={styles.actionIcon} />
+        {label}
+      </button>
+    </div>
+  );
+}
+
 function LinksSection({
   onOpenPrivacy,
   onOpenAbout,
@@ -360,6 +410,7 @@ export function SettingsSidebar({
   onOpenAbout,
   onOpenPrivacy,
   onWeekStartChange,
+  onExport,
 }: SettingsSidebarProps) {
   const { theme, setTheme } = useTheme();
   const weather = useWeatherContext();
@@ -468,6 +519,13 @@ export function SettingsSidebar({
             onTempUnitChange={handleTempUnitChange}
             onShowWeatherChange={handleShowWeatherChange}
           />
+
+          {onExport && (
+            <>
+              <div className={styles.separator} />
+              <DataSection onExport={onExport} />
+            </>
+          )}
 
           <div className={styles.separator} />
 

--- a/src/services/exportNotes.ts
+++ b/src/services/exportNotes.ts
@@ -1,0 +1,145 @@
+import TurndownService from "turndown";
+import { zipSync, strToU8 } from "fflate";
+import type { NoteRepository } from "../storage/noteRepository";
+
+/**
+ * Convert DD-MM-YYYY to YYYY-MM-DD for filenames.
+ */
+export function dateToFilename(date: string): string {
+  const [dd, mm, yyyy] = date.split("-");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Create a turndown instance with custom rules for
+ * timestamp HRs and section labels.
+ */
+export function createTurndown(): TurndownService {
+  const td = new TurndownService({
+    headingStyle: "atx",
+    hr: "---",
+    bulletListMarker: "-",
+  });
+
+  td.addRule("timestampHr", {
+    filter(node) {
+      return (
+        node.nodeName === "HR" &&
+        node.hasAttribute("data-timestamp")
+      );
+    },
+    replacement(_content, node) {
+      const el = node as HTMLElement;
+      const label = el.getAttribute("data-label") ?? "";
+      return label
+        ? `\n\n---\n<!-- time: ${label} -->\n\n`
+        : "\n\n---\n\n";
+    },
+  });
+
+  td.addRule("sectionLabel", {
+    filter(node) {
+      return (
+        node.nodeType === 1 &&
+        (node as HTMLElement).hasAttribute("data-section-type")
+      );
+    },
+    replacement(content) {
+      return `\n\n## ${content.trim()}\n\n`;
+    },
+  });
+
+  td.addRule("imagePlaceholder", {
+    filter(node) {
+      return (
+        node.nodeName === "IMG" &&
+        node.hasAttribute("data-image-id")
+      );
+    },
+    replacement(_content, node) {
+      const id = (node as HTMLElement).getAttribute("data-image-id");
+      return `<!-- image: ${id} -->`;
+    },
+  });
+
+  return td;
+}
+
+/**
+ * Convert note HTML to markdown.
+ */
+export function htmlToMarkdown(
+  html: string,
+  turndown: TurndownService,
+): string {
+  return turndown.turndown(html).trim();
+}
+
+export interface ExportProgress {
+  phase: "fetching" | "converting" | "zipping";
+  current: number;
+  total: number;
+}
+
+/**
+ * Export all notes as a zip of markdown files.
+ * Returns the zip blob for download.
+ */
+export async function exportNotesAsZip(
+  repository: NoteRepository,
+  onProgress?: (progress: ExportProgress) => void,
+): Promise<Blob | null> {
+  const datesResult = await repository.getAllDates();
+  if (!datesResult.ok) {
+    throw new Error(
+      `Failed to fetch note dates: ${datesResult.error.type}`,
+    );
+  }
+
+  const dates = datesResult.value;
+  if (dates.length === 0) return null;
+
+  const total = dates.length;
+  const files: Record<string, Uint8Array> = {};
+  const turndown = createTurndown();
+
+  for (let i = 0; i < dates.length; i++) {
+    onProgress?.({ phase: "fetching", current: i + 1, total });
+
+    const noteResult = await repository.get(dates[i]);
+    if (!noteResult.ok || !noteResult.value) continue;
+
+    const md = htmlToMarkdown(noteResult.value.content, turndown);
+    if (!md) continue;
+
+    const filename = `${dateToFilename(dates[i])}.md`;
+    files[filename] = strToU8(md);
+  }
+
+  if (Object.keys(files).length === 0) return null;
+
+  onProgress?.({
+    phase: "zipping",
+    current: total,
+    total,
+  });
+
+  const zipped = zipSync(files);
+  return new Blob([zipped.buffer as ArrayBuffer], {
+    type: "application/zip",
+  });
+}
+
+/**
+ * Trigger browser download of a blob.
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2152,6 +2152,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@mixmark-io/domino@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@mixmark-io/domino@npm:2.2.0"
+  checksum: 10c0/aa468a15f9217d425220fe6a4b3f9416cbe8e566ee14efc191c6d5cc04fe39338b16a90bbac190f28d44e69465db5f2cf95f479c621ce38060ca6b2a3d346e9d
+  languageName: node
+  linkType: hard
+
 "@napi-rs/wasm-runtime@npm:^1.1.1":
   version: 1.1.1
   resolution: "@napi-rs/wasm-runtime@npm:1.1.1"
@@ -3246,6 +3253,13 @@ __metadata:
   version: 2.0.7
   resolution: "@types/trusted-types@npm:2.0.7"
   checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
+  languageName: node
+  linkType: hard
+
+"@types/turndown@npm:^5.0.6":
+  version: 5.0.6
+  resolution: "@types/turndown@npm:5.0.6"
+  checksum: 10c0/cc5648c115b67ba413782fd0a8ae273ad6b87940df770ab9a5fefe0303c368704013fca2a55dd08f46a2132a747912fd47f96a83162c47fd189babf1352ac4be
   languageName: node
   linkType: hard
 
@@ -4919,6 +4933,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fflate@npm:^0.8.2":
+  version: 0.8.2
+  resolution: "fflate@npm:0.8.2"
+  checksum: 10c0/03448d630c0a583abea594835a9fdb2aaf7d67787055a761515bf4ed862913cfd693b4c4ffd5c3f3b355a70cf1e19033e9ae5aedcca103188aaff91b8bd6e293
+  languageName: node
+  linkType: hard
+
 "file-entry-cache@npm:^8.0.0":
   version: 8.0.0
   resolution: "file-entry-cache@npm:8.0.0"
@@ -5398,6 +5419,7 @@ __metadata:
     "@types/node": "npm:^24.10.1"
     "@types/react": "npm:^19.2.5"
     "@types/react-dom": "npm:^19.2.3"
+    "@types/turndown": "npm:^5.0.6"
     "@vitejs/plugin-react": "npm:^6.0.1"
     cheerio: "npm:^1.0.0"
     dompurify: "npm:^3.3.1"
@@ -5406,6 +5428,7 @@ __metadata:
     eslint-plugin-react-hooks: "npm:^7.0.1"
     eslint-plugin-react-refresh: "npm:^0.4.24"
     fake-indexeddb: "npm:^6.2.3"
+    fflate: "npm:^0.8.2"
     globals: "npm:^16.5.0"
     husky: "npm:^9.1.7"
     jsdom: "npm:^28.1.0"
@@ -5415,6 +5438,7 @@ __metadata:
     react: "npm:^19.2.0"
     react-dom: "npm:^19.2.0"
     supabase: "npm:^2.70.5"
+    turndown: "npm:^7.2.2"
     typescript: "npm:~5.9.3"
     typescript-eslint: "npm:^8.46.4"
     vite: "npm:^8.0.0"
@@ -7912,6 +7936,15 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
+"turndown@npm:^7.2.2":
+  version: 7.2.2
+  resolution: "turndown@npm:7.2.2"
+  dependencies:
+    "@mixmark-io/domino": "npm:^2.2.0"
+  checksum: 10c0/ee09f7bd67c468505aad6c3a26b11269ca49ffce07eaa9c212926d068f242b11b4e955b31a58289f26674ff29f91209b29454907551dcaec7da712e524cc78c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolves #28

- Export all notes as markdown files in a zip (`ichinichi-export-YYYY-MM-DD.zip`)
- New "Data" section in Settings sidebar with "Export as Markdown" button
- HTML-to-markdown via turndown with custom rules:
  - Timestamp HRs → `--- <!-- time: X -->`
  - Section labels → `## +label`
  - Image refs → `<!-- image: id -->`
- Zip compression via fflate
- 16 unit tests for conversion logic and zip generation

## Test plan

- [ ] Open Settings, verify "Data" section appears between Weather and Links
- [ ] Click "Export as Markdown", verify zip downloads
- [ ] Unzip and verify markdown files are named `YYYY-MM-DD.md`
- [ ] Verify timestamp HRs and section labels convert correctly
- [ ] Verify button shows "Exporting..." then "Exported!" states

🤖 Generated with [Claude Code](https://claude.com/claude-code)