### PR TITLE
Fix local-only users losing data after RxDB migration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,12 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", varsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+      ],
+    },
   },
 
   // ── Layer boundary rules ──────────────────────────────────────────

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,9 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { UpdatePrompt } from "./components/UpdatePrompt";
 import { SettingsSidebar } from "./components/SettingsSidebar";
 import { SearchOverlay } from "./components/Search";
-import { exportNotesAsZip, downloadBlob } from "./services/exportNotes";
+import { collectLegacyMarkdown, exportNotesAsZip, downloadBlob } from "./services/exportNotes";
+import { openLegacyIDBSource } from "./storage/legacyIDBSource";
+import { useServiceContext } from "./contexts/serviceContext";
 import { AboutModal } from "./components/AppModals/AboutModal";
 import { PrivacyPolicyModal } from "./components/AppModals/PrivacyPolicyModal";
 import { ResetPasswordModal } from "./components/AppModals/ResetPasswordModal";
@@ -138,13 +140,34 @@ function App() {
     setWeekStartVersion((value) => value + 1);
   }, []);
 
+  const { e2eeFactory } = useServiceContext();
   const handleExport = useCallback(async () => {
     if (!notes.repository) return;
-    const blob = await exportNotesAsZip(notes.repository);
+
+    // Best-effort: also pull decryptable notes from the legacy
+    // `dailynotes-unified` IDB so users who predate PR #68 don't lose data
+    // just because their data hasn't been migrated into RxDB yet.
+    let legacyExtras: Record<string, string> | undefined;
+    if (activeVault.activeKeyId && activeVault.keyring.size > 0) {
+      const source = await openLegacyIDBSource();
+      if (source) {
+        try {
+          const e2ee = e2eeFactory.create({
+            activeKeyId: activeVault.activeKeyId,
+            getKey: (keyId) => activeVault.keyring.get(keyId) ?? null,
+          });
+          legacyExtras = await collectLegacyMarkdown(source, e2ee);
+        } finally {
+          await source.destroy();
+        }
+      }
+    }
+
+    const blob = await exportNotesAsZip(notes.repository, undefined, legacyExtras);
     if (!blob) return;
     const today = new Date().toISOString().slice(0, 10);
     downloadBlob(blob, `ichinichi-export-${today}.zip`);
-  }, [notes.repository]);
+  }, [notes.repository, activeVault.activeKeyId, activeVault.keyring, e2eeFactory]);
 
   const signInHandler =
     appMode.mode !== AppMode.Cloud && auth.authState !== AuthState.SignedIn

--- a/src/__tests__/rxdb/legacyMigration.test.ts
+++ b/src/__tests__/rxdb/legacyMigration.test.ts
@@ -1,6 +1,66 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { createAppDatabase, type AppDatabase } from "../../storage/rxdb/database";
-import { migrateLegacyData, type LegacyDataSource, type LegacyNote, type LegacyImageMeta } from "../../storage/legacyMigration";
+import {
+  migrateLegacyData,
+  type LegacyDataSource,
+  type LegacyEncryptedNote,
+  type LegacyImageMeta,
+  type LegacyEncryptedImageData,
+} from "../../storage/legacyMigration";
+import type { E2eeService, NotePayload } from "../../domain/crypto/e2eeService";
+
+function makeE2ee(overrides: Partial<E2eeService> = {}): E2eeService {
+  const decryptNoteRecord = vi.fn(async (record: { ciphertext: string }) => {
+    try {
+      return JSON.parse(record.ciphertext) as NotePayload;
+    } catch {
+      return null;
+    }
+  });
+  const decryptImageRecord = vi.fn(
+    async (record: { ciphertext: string }, mimeType: string) => {
+      if (record.ciphertext === "__fail__") return null;
+      return new Blob([record.ciphertext], { type: mimeType });
+    },
+  );
+  return {
+    encryptNoteContent: vi.fn().mockResolvedValue(null),
+    decryptNoteRecord,
+    encryptImageBlob: vi.fn().mockResolvedValue(null),
+    decryptImageRecord,
+    ...overrides,
+  };
+}
+
+function encryptedNote(
+  date: string,
+  content: string,
+  updatedAt = "2024-01-01T00:00:00Z",
+  weather: NotePayload["weather"] = null,
+): LegacyEncryptedNote {
+  return {
+    date,
+    keyId: "k1",
+    ciphertext: JSON.stringify({ content, weather }),
+    nonce: "n",
+    updatedAt,
+  };
+}
+
+function makeMockSource(
+  notes: LegacyEncryptedNote[] = [],
+  images: LegacyImageMeta[] = [],
+  imageData: Record<string, LegacyEncryptedImageData> = {},
+): LegacyDataSource {
+  return {
+    getNotes: vi.fn().mockResolvedValue(notes),
+    getImages: vi.fn().mockResolvedValue(images),
+    getImageData: vi.fn().mockImplementation((id: string) =>
+      Promise.resolve(imageData[id] ?? null),
+    ),
+    destroy: vi.fn().mockResolvedValue(undefined),
+  };
+}
 
 describe("migrateLegacyData", () => {
   let db: AppDatabase | null = null;
@@ -13,43 +73,31 @@ describe("migrateLegacyData", () => {
   });
 
   async function makeDb() {
-    db = await createAppDatabase(`test-migration-${Date.now()}-${Math.random()}`, { memory: true });
+    db = await createAppDatabase(
+      `test-migration-${Date.now()}-${Math.random()}`,
+      { memory: true },
+    );
     return db;
   }
 
-  function makeMockSource(
-    notes: LegacyNote[] = [],
-    images: LegacyImageMeta[] = [],
-    blobs: Record<string, Blob> = {},
-  ): LegacyDataSource {
-    return {
-      getNotes: vi.fn().mockResolvedValue(notes),
-      getImages: vi.fn().mockResolvedValue(images),
-      getImageBlob: vi.fn().mockImplementation((id: string) =>
-        Promise.resolve(blobs[id] ?? null),
-      ),
-      destroy: vi.fn().mockResolvedValue(undefined),
-    };
-  }
-
-  it("migrates notes from legacy source to RxDB", async () => {
+  it("decrypts and migrates encrypted notes into RxDB", async () => {
     const database = await makeDb();
-    const notes: LegacyNote[] = [
-      { date: "01-01-2024", content: "Hello world", updatedAt: "2024-01-01T10:00:00Z" },
-      { date: "15-06-2024", content: "Summer note", updatedAt: "2024-06-15T08:30:00Z" },
+    const notes = [
+      encryptedNote("01-01-2024", "Hello world", "2024-01-01T10:00:00Z"),
+      encryptedNote("15-06-2024", "Summer note", "2024-06-15T08:30:00Z"),
     ];
     const source = makeMockSource(notes);
 
-    await migrateLegacyData(database, source);
+    const result = await migrateLegacyData(database, source, makeE2ee());
+    expect(result.migratedNotes).toBe(2);
+    expect(result.failedNotes).toBe(0);
 
     const doc1 = await database.notes.findOne("01-01-2024").exec();
-    expect(doc1).not.toBeNull();
     expect(doc1?.content).toBe("Hello world");
     expect(doc1?.updatedAt).toBe("2024-01-01T10:00:00Z");
     expect(doc1?.isDeleted).toBe(false);
 
     const doc2 = await database.notes.findOne("15-06-2024").exec();
-    expect(doc2).not.toBeNull();
     expect(doc2?.content).toBe("Summer note");
   });
 
@@ -62,27 +110,19 @@ describe("migrateLegacyData", () => {
       unit: "C" as const,
       city: "Tokyo",
     };
-    const notes: LegacyNote[] = [
-      {
-        date: "25-07-2024",
-        content: "Hot day",
-        updatedAt: "2024-07-25T12:00:00Z",
-        weather,
-      },
-    ];
-    const source = makeMockSource(notes);
+    const source = makeMockSource([
+      encryptedNote("25-07-2024", "Hot day", "2024-07-25T12:00:00Z", weather),
+    ]);
 
-    await migrateLegacyData(database, source);
+    await migrateLegacyData(database, source, makeE2ee());
 
     const doc = await database.notes.findOne("25-07-2024").exec();
-    expect(doc).not.toBeNull();
     expect(doc?.weather).toEqual(weather);
   });
 
   it("skips already-existing notes (idempotent)", async () => {
     const database = await makeDb();
 
-    // Pre-insert a note
     await database.notes.insert({
       date: "10-03-2024",
       content: "Existing note",
@@ -90,28 +130,49 @@ describe("migrateLegacyData", () => {
       isDeleted: false,
     });
 
-    const notes: LegacyNote[] = [
-      { date: "10-03-2024", content: "Legacy version", updatedAt: "2024-03-10T08:00:00Z" },
-    ];
-    const source = makeMockSource(notes);
+    const source = makeMockSource([
+      encryptedNote("10-03-2024", "Legacy version", "2024-03-10T08:00:00Z"),
+    ]);
 
-    // Should not throw, should not overwrite
-    await migrateLegacyData(database, source);
+    await migrateLegacyData(database, source, makeE2ee());
 
     const doc = await database.notes.findOne("10-03-2024").exec();
     expect(doc?.content).toBe("Existing note");
+  });
+
+  it("counts decryption failures instead of inserting", async () => {
+    const database = await makeDb();
+    const source = makeMockSource([
+      {
+        date: "02-02-2024",
+        keyId: "missing-key",
+        ciphertext: "garbage",
+        nonce: "n",
+        updatedAt: "2024-02-02T00:00:00Z",
+      },
+    ]);
+    const e2ee = makeE2ee({
+      decryptNoteRecord: vi.fn().mockResolvedValue(null),
+    });
+
+    const result = await migrateLegacyData(database, source, e2ee);
+    expect(result.migratedNotes).toBe(0);
+    expect(result.failedNotes).toBe(1);
+
+    const doc = await database.notes.findOne("02-02-2024").exec();
+    expect(doc).toBeNull();
   });
 
   it("calls destroy on legacy source after migration", async () => {
     const database = await makeDb();
     const source = makeMockSource();
 
-    await migrateLegacyData(database, source);
+    await migrateLegacyData(database, source, makeE2ee());
 
     expect(source.destroy).toHaveBeenCalledOnce();
   });
 
-  it("migrates images from legacy source to RxDB", async () => {
+  it("decrypts and migrates images as blob attachments", async () => {
     const database = await makeDb();
     const images: LegacyImageMeta[] = [
       {
@@ -126,25 +187,24 @@ describe("migrateLegacyData", () => {
         createdAt: "2024-04-20T14:00:00Z",
       },
     ];
-    const blob = new Blob(["fake-png-data"], { type: "image/png" });
-    const source = makeMockSource([], images, { "img-001": blob });
+    const imageData: Record<string, LegacyEncryptedImageData> = {
+      "img-001": { keyId: "k1", ciphertext: "fake-png-data", nonce: "n" },
+    };
+    const source = makeMockSource([], images, imageData);
 
-    await migrateLegacyData(database, source);
+    const result = await migrateLegacyData(database, source, makeE2ee());
+    expect(result.migratedImages).toBe(1);
 
     const doc = await database.images.findOne("img-001").exec();
-    expect(doc).not.toBeNull();
     expect(doc?.noteDate).toBe("20-04-2024");
     expect(doc?.filename).toBe("photo.png");
     expect(doc?.isDeleted).toBe(false);
-
-    const attachment = doc?.getAttachment("blob");
-    expect(attachment).not.toBeNull();
+    expect(doc?.getAttachment("blob")).not.toBeNull();
   });
 
   it("skips already-existing images (idempotent)", async () => {
     const database = await makeDb();
 
-    // Pre-insert image
     await database.images.insert({
       id: "img-existing",
       noteDate: "05-05-2024",
@@ -171,20 +231,21 @@ describe("migrateLegacyData", () => {
         createdAt: "2024-05-05T10:00:00Z",
       },
     ];
-    const source = makeMockSource([], images);
+    const source = makeMockSource([], images, {
+      "img-existing": { ciphertext: "data", nonce: "n" },
+    });
 
-    await migrateLegacyData(database, source);
+    await migrateLegacyData(database, source, makeE2ee());
 
     const doc = await database.images.findOne("img-existing").exec();
-    // Filename should remain unchanged (not overwritten)
     expect(doc?.filename).toBe("existing.jpg");
   });
 
-  it("handles missing image blobs gracefully", async () => {
+  it("counts image failures when image data is missing", async () => {
     const database = await makeDb();
     const images: LegacyImageMeta[] = [
       {
-        id: "img-no-blob",
+        id: "img-no-data",
         noteDate: "15-08-2024",
         type: "inline",
         filename: "missing.png",
@@ -195,14 +256,13 @@ describe("migrateLegacyData", () => {
         createdAt: "2024-08-15T10:00:00Z",
       },
     ];
-    // No blob provided — getImageBlob returns null
     const source = makeMockSource([], images, {});
 
-    // Should not throw
-    await expect(migrateLegacyData(database, source)).resolves.toBeUndefined();
+    const result = await migrateLegacyData(database, source, makeE2ee());
+    expect(result.migratedImages).toBe(0);
+    expect(result.failedImages).toBe(1);
 
-    // Metadata should still be inserted
-    const doc = await database.images.findOne("img-no-blob").exec();
-    expect(doc).not.toBeNull();
+    const doc = await database.images.findOne("img-no-data").exec();
+    expect(doc).toBeNull();
   });
 });

--- a/src/hooks/useNoteRepository.ts
+++ b/src/hooks/useNoteRepository.ts
@@ -6,7 +6,8 @@ import type { ImageRepository } from "../storage/imageRepository";
 import type { AppDatabase } from "../storage/rxdb/database";
 import type { ReplicationHandle } from "../storage/rxdb/replication";
 import { createAppDatabase } from "../storage/rxdb/database";
-import { migrateLegacyData, type LegacyDataSource } from "../storage/legacyMigration";
+import { migrateLegacyData } from "../storage/legacyMigration";
+import { legacyDBExists, openLegacyIDBSource } from "../storage/legacyIDBSource";
 import { RxDBNoteRepository } from "../storage/rxdb/noteRepository";
 import { RxDBImageRepository } from "../storage/rxdb/imageRepository";
 import { startReplication, createImageCryptoAdapter, createRemoteBlobFetcher } from "../storage/rxdb/replication";
@@ -16,7 +17,6 @@ import { useServiceContext } from "../contexts/serviceContext";
 import { SyncStatus } from "../types";
 import type { Note, SavedWeather } from "../types";
 import { reportError } from "../utils/errorReporter";
-import { parseSavedWeather } from "../storage/parsers";
 
 interface UseNoteRepositoryProps {
   mode: AppMode;
@@ -303,140 +303,8 @@ export function noteRepoReducer(
 // Hook
 // ---------------------------------------------------------------------------
 
-const LEGACY_DB_NAME = "dailynotes-unified";
 const LEGACY_MIGRATED_KEY = "ichinichi_legacy_migrated";
 const SAVE_DEBOUNCE_MS = 500;
-
-/**
- * Checks for a legacy IndexedDB database and migrates data to RxDB if found.
- * Only runs once (gates on localStorage flag).
- */
-async function tryMigrateLegacy(db: AppDatabase): Promise<void> {
-  if (typeof indexedDB === "undefined") return;
-  if (localStorage.getItem(LEGACY_MIGRATED_KEY)) return;
-
-  // Check if legacy database exists
-  const databases = await indexedDB.databases?.() ?? [];
-  const hasLegacy = databases.some((d) => d.name === LEGACY_DB_NAME);
-  if (!hasLegacy) {
-    localStorage.setItem(LEGACY_MIGRATED_KEY, "1");
-    return;
-  }
-
-  // Create a minimal legacy data source that reads from the old IDB
-  const source = await createLegacyIDBSource();
-  if (!source) {
-    localStorage.setItem(LEGACY_MIGRATED_KEY, "1");
-    return;
-  }
-
-  try {
-    await migrateLegacyData(db, source);
-  } catch (error) {
-    reportError("useNoteRepository.legacyMigration", error);
-  }
-
-  localStorage.setItem(LEGACY_MIGRATED_KEY, "1");
-}
-
-/**
- * Opens the legacy dailynotes-unified IDB and returns a LegacyDataSource,
- * or null if the database cannot be opened.
- */
-function createLegacyIDBSource(): Promise<LegacyDataSource | null> {
-  return new Promise((resolve) => {
-    const request = indexedDB.open(LEGACY_DB_NAME);
-
-    request.onerror = () => resolve(null);
-
-    request.onsuccess = () => {
-      const idb = request.result;
-      const storeNames = Array.from(idb.objectStoreNames);
-
-      // If no recognizable stores, skip
-      if (!storeNames.includes("notes") && !storeNames.includes("note_meta")) {
-        idb.close();
-        resolve(null);
-        return;
-      }
-
-      resolve({
-        async getNotes() {
-          if (!storeNames.includes("notes")) return [];
-          return new Promise((res, rej) => {
-            const tx = idb.transaction("notes", "readonly");
-            const store = tx.objectStore("notes");
-            const req = store.getAll();
-            req.onsuccess = () => {
-              const raw = req.result ?? [];
-              res(raw.filter((n: Record<string, unknown>) =>
-                typeof n.date === "string" && typeof n.content === "string"
-              ).map((n: Record<string, unknown>) => ({
-                date: n.date as string,
-                content: n.content as string,
-                updatedAt: typeof n.updatedAt === "string" ? n.updatedAt : new Date().toISOString(),
-                weather: parseSavedWeather(n.weather) ?? null,
-              })));
-            };
-            req.onerror = () => rej(req.error);
-          });
-        },
-
-        async getImages() {
-          if (!storeNames.includes("images") && !storeNames.includes("image_meta")) return [];
-          const metaStore = storeNames.includes("image_meta") ? "image_meta" : "images";
-          return new Promise((res, rej) => {
-            const tx = idb.transaction(metaStore, "readonly");
-            const store = tx.objectStore(metaStore);
-            const req = store.getAll();
-            req.onsuccess = () => {
-              const raw = req.result ?? [];
-              res(raw.filter((i: Record<string, unknown>) =>
-                typeof i.id === "string" && typeof i.noteDate === "string"
-              ).map((i: Record<string, unknown>) => ({
-                id: i.id as string,
-                noteDate: i.noteDate as string,
-                type: i.type === "background" || i.type === "inline" ? i.type : "inline",
-                filename: typeof i.filename === "string" ? i.filename : "",
-                mimeType: typeof i.mimeType === "string" ? i.mimeType : "application/octet-stream",
-                width: typeof i.width === "number" ? i.width : 0,
-                height: typeof i.height === "number" ? i.height : 0,
-                size: typeof i.size === "number" ? i.size : 0,
-                createdAt: typeof i.createdAt === "string" ? i.createdAt : new Date().toISOString(),
-              })));
-            };
-            req.onerror = () => rej(req.error);
-          });
-        },
-
-        async getImageBlob(id: string) {
-          if (!storeNames.includes("images")) return null;
-          return new Promise((res, rej) => {
-            const tx = idb.transaction("images", "readonly");
-            const store = tx.objectStore("images");
-            const req = store.get(id);
-            req.onsuccess = () => {
-              const data = req.result;
-              if (data?.blob instanceof Blob) return res(data.blob);
-              res(null);
-            };
-            req.onerror = () => rej(req.error);
-          });
-        },
-
-        async destroy() {
-          idb.close();
-        },
-      });
-    };
-
-    // If upgrade is triggered, the DB doesn't exist in the expected format
-    request.onupgradeneeded = () => {
-      request.transaction?.abort();
-      resolve(null);
-    };
-  });
-}
 
 export function useNoteRepository({
   mode,
@@ -501,11 +369,6 @@ export function useNoteRepository({
       try {
         const newDb = await createAppDatabase(dbName);
         if (cancelled) return;
-
-        // Attempt legacy data migration if the old database exists
-        await tryMigrateLegacy(newDb);
-        if (cancelled) return;
-
         dispatch({ type: "DB_OPENED", db: newDb, dbName });
       } catch (error) {
         reportError("useNoteRepository.openDb", error);
@@ -591,6 +454,57 @@ export function useNoteRepository({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.phase, state.db]);
+
+  // --- Effect 3b: Legacy IndexedDB → RxDB migration ---
+  // Runs once per device after both (a) the RxDB database is open and
+  // (b) a keyring + active key are available, so encrypted legacy notes
+  // can be decrypted. Keyed on LEGACY_MIGRATED_KEY to avoid re-running.
+  useEffect(() => {
+    if (!state.db) return;
+    if (!activeKeyId || keyring.size === 0) return;
+    if (typeof localStorage !== "undefined" && localStorage.getItem(LEGACY_MIGRATED_KEY)) return;
+
+    let cancelled = false;
+    const db = state.db;
+
+    void (async () => {
+      try {
+        if (!(await legacyDBExists())) {
+          if (!cancelled) localStorage.setItem(LEGACY_MIGRATED_KEY, "1");
+          return;
+        }
+
+        const source = await openLegacyIDBSource();
+        if (cancelled) {
+          await source?.destroy();
+          return;
+        }
+        if (!source) {
+          localStorage.setItem(LEGACY_MIGRATED_KEY, "1");
+          return;
+        }
+
+        const e2ee = e2eeFactory.create({
+          activeKeyId,
+          getKey: (keyId: string) => keyringRef.current.get(keyId) ?? null,
+        });
+
+        const result = await migrateLegacyData(db, source, e2ee);
+        if (cancelled) return;
+
+        // Only mark as migrated if every note/image we found was migrated.
+        // When some records failed (missing key), leave the flag unset so a
+        // later session with more keys can pick them up.
+        if (result.failedNotes === 0 && result.failedImages === 0) {
+          localStorage.setItem(LEGACY_MIGRATED_KEY, "1");
+        }
+      } catch (error) {
+        reportError("useNoteRepository.legacyMigration", error);
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [state.db, activeKeyId, keyring, e2eeFactory]);
 
   // --- Effect 4: Subscribe to note document (content + soft-delete) ---
   useEffect(() => {

--- a/src/hooks/useNoteRepository.ts
+++ b/src/hooks/useNoteRepository.ts
@@ -303,7 +303,12 @@ export function noteRepoReducer(
 // Hook
 // ---------------------------------------------------------------------------
 
-const LEGACY_MIGRATED_KEY = "ichinichi_legacy_migrated";
+// v2: bumped from "ichinichi_legacy_migrated" because the initial RxDB cutover
+// (#68) set that flag after silently migrating zero notes (the reader filtered
+// on a plaintext `content` field that never existed — legacy rows were
+// encrypted). Bumping the key forces a single retry for every device where the
+// broken migration ran.
+const LEGACY_MIGRATED_KEY = "ichinichi_legacy_migrated_v2";
 const SAVE_DEBOUNCE_MS = 500;
 
 export function useNoteRepository({

--- a/src/services/exportNotes.ts
+++ b/src/services/exportNotes.ts
@@ -1,6 +1,9 @@
 import TurndownService from "turndown";
 import { zipSync, strToU8 } from "fflate";
 import type { NoteRepository } from "../storage/noteRepository";
+import type { LegacyDataSource } from "../storage/legacyMigration";
+import { decryptLegacyNotes } from "../storage/legacyMigration";
+import type { E2eeService } from "../domain/crypto/e2eeService";
 
 /**
  * Convert DD-MM-YYYY to YYYY-MM-DD for filenames.
@@ -82,12 +85,38 @@ export interface ExportProgress {
 }
 
 /**
+ * Convert decrypted legacy IDB notes into a `{ filename → markdown }` map.
+ * Used as an additional source when exporting so data from the pre-RxDB
+ * `dailynotes-unified` database is recoverable even if migration hasn't run.
+ */
+export async function collectLegacyMarkdown(
+  source: LegacyDataSource,
+  e2ee: E2eeService,
+): Promise<Record<string, string>> {
+  const turndown = createTurndown();
+  const notes = await decryptLegacyNotes(source, e2ee);
+  const files: Record<string, string> = {};
+  for (const note of notes) {
+    const md = htmlToMarkdown(note.content, turndown);
+    if (!md) continue;
+    files[`${dateToFilename(note.date)}.md`] = md;
+  }
+  return files;
+}
+
+/**
  * Export all notes as a zip of markdown files.
  * Returns the zip blob for download.
+ *
+ * When `legacyExtras` is provided, entries not already in the repository are
+ * merged in (repository data takes precedence for duplicate dates). This is
+ * the recovery path for notes still sitting in the legacy IDB that for any
+ * reason haven't been migrated into RxDB yet.
  */
 export async function exportNotesAsZip(
   repository: NoteRepository,
   onProgress?: (progress: ExportProgress) => void,
+  legacyExtras?: Record<string, string>,
 ): Promise<Blob | null> {
   const datesResult = await repository.getAllDates();
   if (!datesResult.ok) {
@@ -97,8 +126,6 @@ export async function exportNotesAsZip(
   }
 
   const dates = datesResult.value;
-  if (dates.length === 0) return null;
-
   const total = dates.length;
   const files: Record<string, Uint8Array> = {};
   const turndown = createTurndown();
@@ -114,6 +141,13 @@ export async function exportNotesAsZip(
 
     const filename = `${dateToFilename(dates[i])}.md`;
     files[filename] = strToU8(md);
+  }
+
+  if (legacyExtras) {
+    for (const [filename, md] of Object.entries(legacyExtras)) {
+      if (filename in files) continue;
+      files[filename] = strToU8(md);
+    }
   }
 
   if (Object.keys(files).length === 0) return null;

--- a/src/storage/legacyIDBSource.ts
+++ b/src/storage/legacyIDBSource.ts
@@ -1,0 +1,173 @@
+import type {
+  LegacyDataSource,
+  LegacyEncryptedImageData,
+  LegacyEncryptedNote,
+  LegacyImageMeta,
+} from "./legacyMigration";
+import { parseSavedWeather } from "./parsers";
+
+export const LEGACY_DB_NAME = "dailynotes-unified";
+
+function isString(v: unknown): v is string {
+  return typeof v === "string";
+}
+
+function isNumber(v: unknown): v is number {
+  return typeof v === "number";
+}
+
+function parseLegacyNote(raw: Record<string, unknown>): LegacyEncryptedNote | null {
+  if (!isString(raw.date)) return null;
+  if (!isString(raw.ciphertext) || !isString(raw.nonce)) return null;
+  return {
+    date: raw.date,
+    keyId: isString(raw.keyId) ? raw.keyId : null,
+    ciphertext: raw.ciphertext,
+    nonce: raw.nonce,
+    updatedAt: isString(raw.updatedAt) ? raw.updatedAt : new Date().toISOString(),
+  };
+}
+
+function parseLegacyImageMeta(raw: Record<string, unknown>): LegacyImageMeta | null {
+  if (!isString(raw.id) || !isString(raw.noteDate)) return null;
+  const type = raw.type === "background" || raw.type === "inline" ? raw.type : "inline";
+  return {
+    id: raw.id,
+    noteDate: raw.noteDate,
+    type,
+    filename: isString(raw.filename) ? raw.filename : "",
+    mimeType: isString(raw.mimeType) ? raw.mimeType : "application/octet-stream",
+    width: isNumber(raw.width) ? raw.width : 0,
+    height: isNumber(raw.height) ? raw.height : 0,
+    size: isNumber(raw.size) ? raw.size : 0,
+    createdAt: isString(raw.createdAt) ? raw.createdAt : new Date().toISOString(),
+  };
+}
+
+function parseLegacyImageData(raw: unknown): LegacyEncryptedImageData | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (!isString(r.ciphertext) || !isString(r.nonce)) return null;
+  return {
+    keyId: isString(r.keyId) ? r.keyId : null,
+    ciphertext: r.ciphertext,
+    nonce: r.nonce,
+  };
+}
+
+/**
+ * Read `parseSavedWeather` attached to legacy decrypted payload form (if ever
+ * stored in plaintext by an old migration). Not used for encrypted records but
+ * kept for safety.
+ */
+export function coerceWeather(raw: unknown) {
+  return parseSavedWeather(raw);
+}
+
+/**
+ * Open the legacy `dailynotes-unified` IndexedDB (if it exists) and expose a
+ * LegacyDataSource. Returns null when the DB is missing or does not have the
+ * expected object stores.
+ */
+export function openLegacyIDBSource(
+  dbName: string = LEGACY_DB_NAME,
+): Promise<LegacyDataSource | null> {
+  if (typeof indexedDB === "undefined") {
+    return Promise.resolve(null);
+  }
+  return new Promise((resolve) => {
+    const request = indexedDB.open(dbName);
+
+    request.onerror = () => resolve(null);
+
+    // If upgrade is triggered, the DB doesn't exist in the expected format.
+    request.onupgradeneeded = () => {
+      request.transaction?.abort();
+      resolve(null);
+    };
+
+    request.onsuccess = () => {
+      const idb = request.result;
+      const storeNames = Array.from(idb.objectStoreNames);
+
+      if (!storeNames.includes("notes")) {
+        idb.close();
+        resolve(null);
+        return;
+      }
+
+      const metaStore = storeNames.includes("image_meta") ? "image_meta" : null;
+
+      resolve({
+        async getNotes() {
+          return new Promise((res, rej) => {
+            const tx = idb.transaction("notes", "readonly");
+            const store = tx.objectStore("notes");
+            const req = store.getAll();
+            req.onsuccess = () => {
+              const raw = (req.result ?? []) as Record<string, unknown>[];
+              const notes = raw
+                .map(parseLegacyNote)
+                .filter((n): n is LegacyEncryptedNote => n !== null);
+              res(notes);
+            };
+            req.onerror = () => rej(req.error);
+          });
+        },
+
+        async getImages() {
+          if (!metaStore) return [];
+          return new Promise((res, rej) => {
+            const tx = idb.transaction(metaStore, "readonly");
+            const store = tx.objectStore(metaStore);
+            const req = store.getAll();
+            req.onsuccess = () => {
+              const raw = (req.result ?? []) as Record<string, unknown>[];
+              const images = raw
+                .map(parseLegacyImageMeta)
+                .filter((i): i is LegacyImageMeta => i !== null);
+              res(images);
+            };
+            req.onerror = () => rej(req.error);
+          });
+        },
+
+        async getImageData(id: string) {
+          if (!storeNames.includes("images")) return null;
+          return new Promise((res, rej) => {
+            const tx = idb.transaction("images", "readonly");
+            const store = tx.objectStore("images");
+            const req = store.get(id);
+            req.onsuccess = () => res(parseLegacyImageData(req.result));
+            req.onerror = () => rej(req.error);
+          });
+        },
+
+        async destroy() {
+          idb.close();
+        },
+      });
+    };
+  });
+}
+
+/**
+ * Check whether the legacy IndexedDB database exists (without opening it).
+ * Falls back to returning true when `indexedDB.databases()` is unsupported —
+ * callers should attempt to open and handle the null case gracefully.
+ */
+export async function legacyDBExists(
+  dbName: string = LEGACY_DB_NAME,
+): Promise<boolean> {
+  if (typeof indexedDB === "undefined") return false;
+  if (typeof indexedDB.databases !== "function") {
+    // Older Firefox lacks this API. Defer to an open+probe from the caller.
+    return true;
+  }
+  try {
+    const dbs = await indexedDB.databases();
+    return dbs.some((d) => d.name === dbName);
+  } catch {
+    return true;
+  }
+}

--- a/src/storage/legacyMigration.ts
+++ b/src/storage/legacyMigration.ts
@@ -1,12 +1,14 @@
 import type { AppDatabase } from "./rxdb/database";
 import type { SavedWeather } from "../types/index";
+import type { E2eeService } from "../domain/crypto/e2eeService";
 import { reportError } from "../utils/errorReporter";
 
-export interface LegacyNote {
+export interface LegacyEncryptedNote {
   date: string;
-  content: string;
+  keyId?: string | null;
+  ciphertext: string;
+  nonce: string;
   updatedAt: string;
-  weather?: SavedWeather | null;
 }
 
 export interface LegacyImageMeta {
@@ -21,38 +23,143 @@ export interface LegacyImageMeta {
   createdAt: string;
 }
 
+export interface LegacyEncryptedImageData {
+  keyId?: string | null;
+  ciphertext: string;
+  nonce: string;
+}
+
 export interface LegacyDataSource {
-  getNotes(): Promise<LegacyNote[]>;
+  getNotes(): Promise<LegacyEncryptedNote[]>;
   getImages(): Promise<LegacyImageMeta[]>;
-  getImageBlob(id: string): Promise<Blob | null>;
+  getImageData(id: string): Promise<LegacyEncryptedImageData | null>;
   destroy(): Promise<void>;
 }
 
+export interface LegacyMigrationResult {
+  migratedNotes: number;
+  migratedImages: number;
+  failedNotes: number;
+  failedImages: number;
+}
+
+export interface DecryptedLegacyNote {
+  date: string;
+  content: string;
+  updatedAt: string;
+  weather?: SavedWeather | null;
+}
+
+/**
+ * Decrypt legacy notes using the provided E2ee service. Notes whose DEK is
+ * missing from the keyring (or which fail to decrypt) are skipped. Returned
+ * in the source order.
+ */
+export async function decryptLegacyNotes(
+  source: LegacyDataSource,
+  e2ee: E2eeService,
+): Promise<DecryptedLegacyNote[]> {
+  const encrypted = await source.getNotes();
+  const out: DecryptedLegacyNote[] = [];
+  for (const note of encrypted) {
+    try {
+      const payload = await e2ee.decryptNoteRecord({
+        keyId: note.keyId ?? null,
+        ciphertext: note.ciphertext,
+        nonce: note.nonce,
+      });
+      if (!payload) continue;
+      out.push({
+        date: note.date,
+        content: payload.content,
+        updatedAt: note.updatedAt,
+        weather: payload.weather ?? null,
+      });
+    } catch (error) {
+      reportError("legacyMigration.decryptLegacyNotes", error);
+    }
+  }
+  return out;
+}
+
+/**
+ * Migrates data from a legacy encrypted IndexedDB store into the RxDB database.
+ * Requires an E2eeService whose keyring holds DEKs for the legacy records;
+ * notes or images whose keys are not available are skipped and counted as
+ * failures so the caller can retry later (e.g. after more keys load).
+ */
 export async function migrateLegacyData(
   db: AppDatabase,
   source: LegacyDataSource,
-): Promise<void> {
+  e2ee: E2eeService,
+): Promise<LegacyMigrationResult> {
+  const result: LegacyMigrationResult = {
+    migratedNotes: 0,
+    migratedImages: 0,
+    failedNotes: 0,
+    failedImages: 0,
+  };
+
   try {
-    // Migrate notes
     const notes = await source.getNotes();
     for (const note of notes) {
       const existing = await db.notes.findOne(note.date).exec();
       if (existing) continue;
 
+      let payload: { content: string; weather?: SavedWeather | null } | null;
+      try {
+        payload = await e2ee.decryptNoteRecord({
+          keyId: note.keyId ?? null,
+          ciphertext: note.ciphertext,
+          nonce: note.nonce,
+        });
+      } catch (error) {
+        reportError("legacyMigration.decryptNote", error);
+        payload = null;
+      }
+
+      if (!payload) {
+        result.failedNotes++;
+        continue;
+      }
+
       await db.notes.insert({
         date: note.date,
-        content: note.content,
+        content: payload.content,
         updatedAt: note.updatedAt,
         isDeleted: false,
-        weather: note.weather ?? null,
+        weather: payload.weather ?? null,
       });
+      result.migratedNotes++;
     }
 
-    // Migrate images
     const images = await source.getImages();
     for (const image of images) {
       const existing = await db.images.findOne(image.id).exec();
       if (existing) continue;
+
+      const encrypted = await source.getImageData(image.id);
+      let blob: Blob | null = null;
+      if (encrypted) {
+        try {
+          blob = await e2ee.decryptImageRecord(
+            {
+              keyId: encrypted.keyId ?? null,
+              ciphertext: encrypted.ciphertext,
+              nonce: encrypted.nonce,
+            },
+            image.mimeType,
+          );
+        } catch (error) {
+          reportError("legacyMigration.decryptImage", error);
+          blob = null;
+        }
+      }
+
+      if (!blob) {
+        result.failedImages++;
+        continue;
+      }
 
       const doc = await db.images.insert({
         id: image.id,
@@ -67,14 +174,12 @@ export async function migrateLegacyData(
         isDeleted: false,
       });
 
-      const blob = await source.getImageBlob(image.id);
-      if (blob) {
-        await doc.putAttachment({
-          id: "blob",
-          data: blob,
-          type: image.mimeType,
-        });
-      }
+      await doc.putAttachment({
+        id: "blob",
+        data: blob,
+        type: image.mimeType,
+      });
+      result.migratedImages++;
     }
 
     await source.destroy();
@@ -82,4 +187,6 @@ export async function migrateLegacyData(
     reportError("legacyMigration.migrateLegacyData", error);
     throw error;
   }
+
+  return result;
 }


### PR DESCRIPTION
Fixes #73.

## Summary
- PR #68's legacy migration assumed plaintext note records, but legacy notes in `dailynotes-unified` were stored encrypted (`{ciphertext, nonce, keyId}`). The filter silently migrated zero records and still set the `ichinichi_legacy_migrated` flag, locking local-only users out of their data with no retry path.
- `migrateLegacyData` / `LegacyDataSource` now carry encrypted records and decrypt via `E2eeService`; migration runs after both RxDB and the keyring+activeKeyId are ready (decryption was impossible at DB-open time). The one-shot flag is only set when every record was successfully decrypted, so missing-key scenarios can retry on a later session.
- Extracted the legacy IDB reader into `storage/legacyIDBSource` for reuse.
- "Export as Markdown" now also pulls decryptable notes from the legacy IDB as a safety net, so users can recover data even if migration didn't fully run.

## Test plan
- [x] `npm test` — 612 tests pass (updated `legacyMigration.test.ts` for the new encrypted signature; 8 tests covering note decryption, weather, idempotency, key-missing failure counts, image attachments, missing-image-data handling)
- [x] `npm run typecheck` — clean
- [ ] Manual: load app as a local-only user with existing `dailynotes-unified` data; unlock vault; verify notes appear
- [ ] Manual: with partial keyring (some keys missing), verify successful notes migrate, missing ones stay in legacy IDB, and `ichinichi_legacy_migrated` is not set
- [ ] Manual: "Export as Markdown" produces a zip that includes legacy-only notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)