### PR TITLE
Add "Jump to today" button on read-only notes

### DIFF
--- a/src/components/NoteEditor/NoteEditor.module.css
+++ b/src/components/NoteEditor/NoteEditor.module.css
@@ -85,6 +85,28 @@
   white-space: nowrap;
 }
 
+.jumpToTodayButton {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  background: none;
+  border: none;
+  padding: var(--spacing-xs) 0;
+  cursor: pointer;
+  white-space: nowrap;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.jumpToTodayButton:hover {
+  color: var(--color-text);
+}
+
+.jumpToTodayButton:focus-visible {
+  outline: 2px solid var(--color-text-muted);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
 .debugKeyBadge {
   font-family: var(--font-family-mono);
   font-size: 11px;

--- a/src/components/NoteEditor/NoteEditor.tsx
+++ b/src/components/NoteEditor/NoteEditor.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo } from "react";
 import type { DragEvent } from "react";
-import { formatDateDisplay, isToday } from "../../utils/date";
+import { formatDateDisplay, getTodayString, isToday } from "../../utils/date";
 import { canEditNote } from "../../utils/noteRules";
+import { useRoutingContext } from "../../contexts/routingContext";
 import { getPlaceholderText } from "../../utils/placeholderText";
 import { NoteEditorView } from "./NoteEditorView";
 import { useContentEditableEditor } from "./useContentEditableEditor";
@@ -64,6 +65,11 @@ export function NoteEditor({
   });
 
   const debugKeyId = useDebugNoteKeyId(date, isContentReady);
+
+  const { navigateToDate } = useRoutingContext();
+  const handleJumpToToday = useCallback(() => {
+    navigateToDate(getTodayString());
+  }, [navigateToDate]);
 
   const { isDraggingImage, endImageDrag } = useImageDragState();
   const weather = useWeatherContext();
@@ -165,6 +171,7 @@ export function NoteEditor({
       isEditable={isEditable}
       autoFocus={autoFocus}
       showReadonlyBadge={!canEdit}
+      onJumpToToday={!canEdit ? handleJumpToToday : undefined}
       statusText={statusText}
       isStatusError={hasError}
       onRestore={isSoftDeleted ? onRestore : undefined}

--- a/src/components/NoteEditor/NoteEditorHeader.tsx
+++ b/src/components/NoteEditor/NoteEditorHeader.tsx
@@ -6,6 +6,7 @@ interface NoteEditorHeaderProps {
   date: string;
   formattedDate: string;
   showReadonlyBadge: boolean;
+  onJumpToToday?: () => void;
   statusText: string | null;
   isStatusError?: boolean;
   onRestore?: () => void;
@@ -17,6 +18,7 @@ export function NoteEditorHeader({
   date,
   formattedDate,
   showReadonlyBadge,
+  onJumpToToday,
   statusText,
   isStatusError = false,
   onRestore,
@@ -41,6 +43,16 @@ export function NoteEditorHeader({
         )}
         {showReadonlyBadge && (
           <span className={styles.readonlyBadge}>Read only</span>
+        )}
+        {showReadonlyBadge && onJumpToToday && (
+          <button
+            type="button"
+            className={styles.jumpToTodayButton}
+            onClick={onJumpToToday}
+            title="Jump to today's note"
+          >
+            Jump to today
+          </button>
         )}
         {debugKeyId && (
           <code className={styles.debugKeyBadge} title={debugKeyId}>

--- a/src/components/NoteEditor/NoteEditorView.tsx
+++ b/src/components/NoteEditor/NoteEditorView.tsx
@@ -22,6 +22,7 @@ interface NoteEditorViewProps {
   isEditable: boolean;
   autoFocus: boolean;
   showReadonlyBadge: boolean;
+  onJumpToToday?: () => void;
   statusText: string | null;
   isStatusError?: boolean;
   onRestore?: () => void;
@@ -47,6 +48,7 @@ export function NoteEditorView({
   isEditable,
   autoFocus,
   showReadonlyBadge,
+  onJumpToToday,
   statusText,
   isStatusError = false,
   onRestore,
@@ -105,6 +107,7 @@ export function NoteEditorView({
         date={date}
         formattedDate={formattedDate}
         showReadonlyBadge={showReadonlyBadge}
+        onJumpToToday={onJumpToToday}
         statusText={statusText}
         isStatusError={isStatusError}
         onRestore={onRestore}


### PR DESCRIPTION
## Summary
- Adds a subtle text-button next to the "Read only" chip on past notes that navigates straight to today, avoiding the calendar round-trip
- Button only appears when the note isn't editable (past dates outside the ≤3am grace window); the "Read only" chip itself is unchanged
- Uses theme `--color-text-muted` / `--color-text` (hover) for styling — no hardcoded colors

Closes #38

## Test plan
- [ ] Open a note for a past date — verify "Read only" chip + "Jump to today" button appear
- [ ] Click "Jump to today" — verify it navigates to today's editable note
- [ ] Open today's note — verify neither the chip nor the button show
- [ ] Leave a past note open past midnight — verify the button appears on the stale tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)